### PR TITLE
Current Text Controller

### DIFF
--- a/example/lib/counter_page.dart
+++ b/example/lib/counter_page.dart
@@ -123,138 +123,159 @@ class _CounterPageState extends CurrentState<CounterPage, CounterViewModel>
       ),
       body: Form(
         key: formKey,
-        child: Center(
-          child: Column(
-            mainAxisAlignment: MainAxisAlignment.center,
-            children: <Widget>[
-              SizedBox(
-                width: _textFieldWidth,
-                child: TextFormField(
-                  controller: nameController,
-                  decoration: const InputDecoration(labelText: 'Name'),
-                ),
-              ),
-              const SizedBox(height: 20),
-              Text.rich(
-                TextSpan(text: 'Hey ', children: [
-                  TextSpan(
-                    text: viewModel.name.value,
-                    style: const TextStyle(fontWeight: FontWeight.bold),
-                  ),
-                  const TextSpan(
-                      text: ', You have pushed the button this many times:'),
-                ]),
-              ),
-              Text(
-                '${viewModel.count}',
-                style: Theme.of(context).textTheme.headlineMedium,
-              ),
-              TextButton(
-                onPressed: () =>
-                    Current.viewModelOf<ApplicationViewModel>(context)
-                        .changeBackgroundColor(Colors.red),
-                child: const Text('Red'),
-              ),
-              TextButton(
-                onPressed: () =>
-                    Current.viewModelOf<ApplicationViewModel>(context)
-                        .changeBackgroundColor(Colors.white),
-                child: const Text('White'),
-              ),
-              TextButton(
-                onPressed: () async {
-                  if (viewModel.changeBackgroundOnCountChange.isFalse) {
-                    await resumeCountChangeSubscription();
-                  } else {
-                    await pauseCountChangeSubscription();
-                  }
-                },
-                child: Text(viewModel.changeBackgroundOnCountChange.isFalse
-                    ? 'Randomize Background Color on Count Change'
-                    : 'Turn Off Random Backgrounds'),
-              ),
-              SizedBox(
-                width: _textFieldWidth,
-                child: TextFormField(
-                  controller: countController,
-                  keyboardType: TextInputType.number,
-                  decoration: InputDecoration(
-                      labelText: 'Set Count',
-                      suffix: IconButton(
-                          onPressed: () {
-                            // Can invoke the `set` function which will trigger the appropriate events and UI updates.
-                            // The set function can be useful as you can use it as a function tear-off.
-                            // For example, you could use it on this TextFormFieldss onFieldSubmitted callback:
-                            // onFieldSubmitted: viewModel.count.set
-                            viewModel.count.set(
-                              int.tryParse(countController.text) ?? 0,
-                            );
+        child: SafeArea(
+          child: LayoutBuilder(
+            builder: (context, constraints) {
+              return SingleChildScrollView(
+                padding: const EdgeInsets.symmetric(vertical: 24),
+                child: ConstrainedBox(
+                  constraints: BoxConstraints(minHeight: constraints.maxHeight),
+                  child: Center(
+                    child: Column(
+                      mainAxisSize: MainAxisSize.min,
+                      children: <Widget>[
+                        SizedBox(
+                          width: _textFieldWidth,
+                          child: TextFormField(
+                            controller: nameController,
+                            decoration:
+                                const InputDecoration(labelText: 'Name'),
+                          ),
+                        ),
+                        const SizedBox(height: 20),
+                        Text.rich(
+                          TextSpan(text: 'Hey ', children: [
+                            TextSpan(
+                              text: viewModel.name.value,
+                              style:
+                                  const TextStyle(fontWeight: FontWeight.bold),
+                            ),
+                            const TextSpan(
+                              text:
+                                  ', You have pushed the button this many times:',
+                            ),
+                          ]),
+                        ),
+                        Text(
+                          '${viewModel.count}',
+                          style: Theme.of(context).textTheme.headlineMedium,
+                        ),
+                        TextButton(
+                          onPressed: () =>
+                              Current.viewModelOf<ApplicationViewModel>(context)
+                                  .changeBackgroundColor(Colors.red),
+                          child: const Text('Red'),
+                        ),
+                        TextButton(
+                          onPressed: () =>
+                              Current.viewModelOf<ApplicationViewModel>(context)
+                                  .changeBackgroundColor(Colors.white),
+                          child: const Text('White'),
+                        ),
+                        TextButton(
+                          onPressed: () async {
+                            if (viewModel
+                                .changeBackgroundOnCountChange.isFalse) {
+                              await resumeCountChangeSubscription();
+                            } else {
+                              await pauseCountChangeSubscription();
+                            }
                           },
-                          icon: Icon(Icons.save))),
-                  onFieldSubmitted: (value) {
-                    // Can directly set the value of the property, which will trigger the appropriate events and UI updates.
-                    // This is more concise and idiomatic. If you want the new value to be treated as the original value, you can use the `set` function with the `setAsOriginal` argument set to true.
-                    viewModel.count.value = int.tryParse(value) ?? 0;
-                  },
-                ),
-              ),
-              const SizedBox(height: 20),
-              Row(
-                spacing: 20,
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  ElevatedButton(
-                    onPressed: viewModel.toggleProductivity,
-                    child: ifBusy(
-                      const Text('Stop Being Productive'),
-                      otherwise: const Text('Be Productive'),
+                          child: Text(
+                              viewModel.changeBackgroundOnCountChange.isFalse
+                                  ? 'Randomize Background Color on Count Change'
+                                  : 'Turn Off Random Backgrounds'),
+                        ),
+                        SizedBox(
+                          width: _textFieldWidth,
+                          child: TextFormField(
+                            controller: countController,
+                            keyboardType: TextInputType.number,
+                            decoration: InputDecoration(
+                                labelText: 'Set Count',
+                                suffix: IconButton(
+                                    onPressed: () {
+                                      // Can invoke the `set` function which will trigger the appropriate events and UI updates.
+                                      // The set function can be useful as you can use it as a function tear-off.
+                                      // For example, you could use it on this TextFormFieldss onFieldSubmitted callback:
+                                      // onFieldSubmitted: viewModel.count.set
+                                      viewModel.count.set(
+                                        int.tryParse(countController.text) ?? 0,
+                                      );
+                                    },
+                                    icon: Icon(Icons.save))),
+                            onFieldSubmitted: (value) {
+                              // Can directly set the value of the property, which will trigger the appropriate events and UI updates.
+                              // This is more concise and idiomatic. If you want the new value to be treated as the original value, you can use the `set` function with the `setAsOriginal` argument set to true.
+                              viewModel.count.value = int.tryParse(value) ?? 0;
+                            },
+                          ),
+                        ),
+                        const SizedBox(height: 20),
+                        Row(
+                          spacing: 20,
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            ElevatedButton(
+                              onPressed: viewModel.toggleProductivity,
+                              child: ifBusy(
+                                const Text('Stop Being Productive'),
+                                otherwise: const Text('Be Productive'),
+                              ),
+                            ),
+                            AnimatedSwitcher(
+                              duration: const Duration(milliseconds: 300),
+                              child: isBusy
+                                  ? const CircularProgressIndicator()
+                                  : const Icon(Icons.work_off),
+                            ),
+                          ],
+                        ),
+                        const SizedBox(height: 20),
+                        ElevatedButton(
+                          onPressed: viewModel.recitePi,
+                          child: const Text('Try To Recite PI'),
+                        ),
+                        const SizedBox(height: 20),
+                        Padding(
+                          padding: const EdgeInsets.symmetric(
+                              vertical: 8.0, horizontal: 32),
+                          child: Text.rich(
+                            textAlign: TextAlign.center,
+                            TextSpan(
+                              text:
+                                  'Notice that the name TextFormField is using a CurrentTextController, and the count TextFormField is using a regular TextEditingController. ',
+                              children: [
+                                TextSpan(
+                                  text:
+                                      '\n\nThe CurrentTextController automatically keeps the value of the TextFormField in sync with the value of the associated CurrentProperty, so when the `name` resets to its original value, the TextFormField will automatically update to reflect that change',
+                                  style: const TextStyle(
+                                      fontWeight: FontWeight.bold),
+                                ),
+                                TextSpan(
+                                  text:
+                                      ' while the `count` TextFormField will not.',
+                                  style: const TextStyle(
+                                      fontWeight: FontWeight.bold),
+                                ),
+                              ],
+                            ),
+                          ),
+                        ),
+                        const SizedBox(height: 20),
+                        TextButton(
+                          onPressed: () {
+                            viewModel.resetAll();
+                            appViewModel.reset();
+                          },
+                          child: const Text('Reset'),
+                        ),
+                      ],
                     ),
                   ),
-                  AnimatedSwitcher(
-                    duration: const Duration(milliseconds: 300),
-                    child: isBusy
-                        ? const CircularProgressIndicator()
-                        : const Icon(Icons.work_off),
-                  ),
-                ],
-              ),
-              const SizedBox(height: 20),
-              ElevatedButton(
-                onPressed: viewModel.recitePi,
-                child: const Text('Try To Recite PI'),
-              ),
-              const SizedBox(height: 20),
-              Padding(
-                padding:
-                    const EdgeInsets.symmetric(vertical: 8.0, horizontal: 32),
-                child: Text.rich(
-                  textAlign: TextAlign.center,
-                  TextSpan(
-                    text:
-                        'Notice that the name TextFormField is using a CurrentTextController, and the count TextFormField is using a regular TextEditingController. ',
-                    children: [
-                      TextSpan(
-                        text:
-                            '\n\nThe CurrentTextController automatically keeps the value of the TextFormField in sync with the value of the associated CurrentProperty, so when the `name` resets to its original value, the TextFormField will automatically update to reflect that change',
-                        style: const TextStyle(fontWeight: FontWeight.bold),
-                      ),
-                      TextSpan(
-                        text: ' while the `count` TextFormField will not.',
-                        style: const TextStyle(fontWeight: FontWeight.bold),
-                      ),
-                    ],
-                  ),
                 ),
-              ),
-              const SizedBox(height: 20),
-              TextButton(
-                onPressed: () {
-                  viewModel.resetAll();
-                  appViewModel.reset();
-                },
-                child: const Text('Reset'),
-              ),
-            ],
+              );
+            },
           ),
         ),
       ),

--- a/example/lib/counter_page.dart
+++ b/example/lib/counter_page.dart
@@ -15,15 +15,27 @@ class CounterPage extends CurrentWidget<CounterViewModel> {
       createCurrent() => _CounterPageState(viewModel);
 }
 
-class _CounterPageState extends CurrentState<CounterPage, CounterViewModel> {
+class _CounterPageState extends CurrentState<CounterPage, CounterViewModel>
+    with CurrentTextControllersLifecycleMixin {
   _CounterPageState(super.viewModel);
+
+  static const double _textFieldWidth = 200;
 
   final formKey = GlobalKey<FormState>();
   final countController = TextEditingController();
+  final nameController = CurrentTextController.string();
 
   late ApplicationViewModel appViewModel;
 
   StreamSubscription? countChangedSubscription;
+
+  @override
+  void bindCurrentControllers() {
+    nameController.bindString(
+      property: viewModel.name,
+      lifecycleProvider: this,
+    );
+  }
 
   @override
   void initState() {
@@ -115,8 +127,15 @@ class _CounterPageState extends CurrentState<CounterPage, CounterViewModel> {
           child: Column(
             mainAxisAlignment: MainAxisAlignment.center,
             children: <Widget>[
-              const Text(
-                'You have pushed the button this many times:',
+              Text.rich(
+                TextSpan(text: 'Hey ', children: [
+                  TextSpan(
+                    text: viewModel.name.value,
+                    style: const TextStyle(fontWeight: FontWeight.bold),
+                  ),
+                  const TextSpan(
+                      text: ', You have pushed the button this many times:'),
+                ]),
               ),
               Text(
                 '${viewModel.count}',
@@ -147,7 +166,7 @@ class _CounterPageState extends CurrentState<CounterPage, CounterViewModel> {
                     : 'Turn Off Random Backgrounds'),
               ),
               SizedBox(
-                width: 200,
+                width: _textFieldWidth,
                 child: TextFormField(
                   controller: countController,
                   keyboardType: TextInputType.number,
@@ -196,9 +215,41 @@ class _CounterPageState extends CurrentState<CounterPage, CounterViewModel> {
                 onPressed: viewModel.recitePi,
                 child: const Text('Try To Recite PI'),
               ),
+              const SizedBox(height: 20),
+              SizedBox(
+                width: _textFieldWidth,
+                child: TextFormField(
+                  controller: nameController,
+                  decoration: const InputDecoration(labelText: 'Name'),
+                ),
+              ),
+              const SizedBox(height: 20),
+              Padding(
+                padding:
+                    const EdgeInsets.symmetric(vertical: 8.0, horizontal: 32),
+                child: Text.rich(
+                  textAlign: TextAlign.center,
+                  TextSpan(
+                    text:
+                        'Notice that the name TextFormField is using a CurrentTextController, and the count TextFormField is using a regular TextEditingController. ',
+                    children: [
+                      TextSpan(
+                        text:
+                            '\n\nThe CurrentTextController automatically keeps the value of the TextFormField in sync with the value of the associated CurrentProperty, so when the `name` resets to its original value, the TextFormField will automatically update to reflect that change',
+                        style: const TextStyle(fontWeight: FontWeight.bold),
+                      ),
+                      TextSpan(
+                        text: ' while the `count` TextFormField will not.',
+                        style: const TextStyle(fontWeight: FontWeight.bold),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+              const SizedBox(height: 20),
               TextButton(
                 onPressed: () {
-                  viewModel.reset();
+                  viewModel.resetAll();
                   appViewModel.reset();
                 },
                 child: const Text('Reset'),

--- a/example/lib/counter_page.dart
+++ b/example/lib/counter_page.dart
@@ -127,6 +127,14 @@ class _CounterPageState extends CurrentState<CounterPage, CounterViewModel>
           child: Column(
             mainAxisAlignment: MainAxisAlignment.center,
             children: <Widget>[
+              SizedBox(
+                width: _textFieldWidth,
+                child: TextFormField(
+                  controller: nameController,
+                  decoration: const InputDecoration(labelText: 'Name'),
+                ),
+              ),
+              const SizedBox(height: 20),
               Text.rich(
                 TextSpan(text: 'Hey ', children: [
                   TextSpan(
@@ -214,14 +222,6 @@ class _CounterPageState extends CurrentState<CounterPage, CounterViewModel>
               ElevatedButton(
                 onPressed: viewModel.recitePi,
                 child: const Text('Try To Recite PI'),
-              ),
-              const SizedBox(height: 20),
-              SizedBox(
-                width: _textFieldWidth,
-                child: TextFormField(
-                  controller: nameController,
-                  decoration: const InputDecoration(labelText: 'Name'),
-                ),
               ),
               const SizedBox(height: 20),
               Padding(

--- a/example/lib/counter_page.dart
+++ b/example/lib/counter_page.dart
@@ -49,8 +49,7 @@ class _CounterPageState extends CurrentState<CounterPage, CounterViewModel>
     }, filter: (event) => event.nextValue == 42);
 
     // Can also listen to all events and filter by property name
-    countChangedSubscription =
-        viewModel.addStateChangedListener((CurrentStateChanged event) {
+    countChangedSubscription = viewModel.addAnyStateChangedListener((event) {
       if (viewModel.changeBackgroundOnCountChange.isTrue) {
         appViewModel.randomizeBackgroundColor();
       }

--- a/example/lib/counter_view_model.dart
+++ b/example/lib/counter_view_model.dart
@@ -2,13 +2,14 @@ import 'package:current/current.dart';
 import 'package:current_counter_example/failed_to_recite_pi.dart';
 
 class CounterViewModel extends CurrentViewModel {
+  final name = CurrentProperty.string(initialValue: 'You');
   final count = CurrentProperty.integer(propertyName: 'count');
 
   final changeBackgroundOnCountChange = CurrentBoolProperty(false);
 
   @override
   List<CurrentProperty> get currentProps {
-    return [count, changeBackgroundOnCountChange];
+    return [name, count, changeBackgroundOnCountChange];
   }
 
   Future<void> incrementCounter() async {
@@ -25,10 +26,5 @@ class CounterViewModel extends CurrentViewModel {
 
   void recitePi() {
     notifyError(FailedToRecitePi('🤯'));
-  }
-
-  void reset() {
-    count.reset();
-    changeBackgroundOnCountChange.reset();
   }
 }

--- a/lib/current.dart
+++ b/lib/current.dart
@@ -6,3 +6,4 @@ export 'src/current_property.dart';
 export 'src/current_view_model.dart';
 export 'src/current_widget.dart';
 export 'src/current_cloneable.dart';
+export 'src/current_text_controller.dart';

--- a/lib/src/current_exceptions.dart
+++ b/lib/src/current_exceptions.dart
@@ -28,6 +28,26 @@ class CurrentPropertyNullValueException extends CurrentPropertyException {
       'CurrentPropertyNullValueException: The underlying value for ${propertyName ?? type} is null.\nStack: $stack';
 }
 
+/// Thrown when a [CurrentIntProperty] arithmetic function cannot convert its numeric result
+/// into the explicitly requested generic type.
+class CurrentIntPropertyInvalidArithmaticException
+    extends CurrentPropertyException {
+  final Type attemptedType;
+  final Type resultType;
+
+  CurrentIntPropertyInvalidArithmaticException(
+    super.stack,
+    super.propertyName,
+    super.type, {
+    required this.attemptedType,
+    required this.resultType,
+  });
+
+  @override
+  String toString() =>
+      'CurrentIntPropertyInvalidArithmaticException: The arithmetic result for ${propertyName ?? type} was $resultType and could not be converted to $attemptedType. Use int, double, or num, or call the non-generic arithmetic helpers.\nStack: $stack';
+}
+
 ///Thrown when an CurrentProperty value is changed and attempts to update the UI, but has not been added to the
 ///currentProps property of the associated CurrentViewModel
 ///

--- a/lib/src/current_exceptions.dart
+++ b/lib/src/current_exceptions.dart
@@ -1,3 +1,5 @@
+import 'package:current/current.dart';
+
 ///Base class for any Current specific exception
 abstract class CurrentException implements Exception {
   final StackTrace? stack;
@@ -39,6 +41,10 @@ class PropertyNotAssignedToCurrentViewModelException
       'PropertyNotAssignedToCurrentViewModelException: The value for ${propertyName ?? type} changed and failed to update the UI. Did you forget to add it to currentProps?.\nStack: $stack';
 }
 
+/// Thrown when a CurrentViewModel is assigned to a CurrentState, but that CurrentViewModel is already assigned to a different CurrentState.
+///
+/// This can occur when a CurrentWidget is rebuilt and attempts to assign the same CurrentViewModel instance to the new CurrentState and [AutomaticKeepAliveClientMixin] is
+/// not being used to preserve the state of the original CurrentState.
 class CurrentViewModelAlreadyAssignedException extends CurrentException {
   CurrentViewModelAlreadyAssignedException(super.stack, super.type);
 
@@ -58,4 +64,61 @@ class CurrentViewModelAlreadyAssignedException extends CurrentException {
 
     return buffer.toString();
   }
+}
+
+/// Base class for exceptions thrown by CurrentTextController when there is an issue with the CurrentProperty it is trying to control.
+///
+abstract class CurrentTextControllerException extends CurrentException {
+  final CurrentProperty? property;
+
+  CurrentTextControllerException(
+    super.stack,
+    super.type,
+    this.property,
+  );
+}
+
+/// Thrown when a [CurrentTextController] is initialized with a [CurrentProperty] type that is not compatible with the controller type requested.
+///
+class CurrentTextControllerCurrentPropertyTypeException
+    extends CurrentTextControllerException {
+  final String attemptedControllerType;
+  final List<Type> validTypes;
+
+  CurrentTextControllerCurrentPropertyTypeException(
+    CurrentProperty property,
+    this.attemptedControllerType,
+    this.validTypes,
+  ) : super(
+          StackTrace.current,
+          property.runtimeType,
+          property,
+        );
+
+  @override
+  String toString() =>
+      'CurrentTextControllerCurrentPropertyTypeException: The property ${property?.propertyName ?? type} is not a valid CurrentProperty type for the controller type "$attemptedControllerType". Valid types are: ${validTypes.join(', ')}\nStack: $stack';
+}
+
+/// Thrown when a the [CurrentTextController.bind] is called more than once.
+class CurrentTextControllerAlreadyInitializedException
+    extends CurrentTextControllerException {
+  CurrentTextControllerAlreadyInitializedException(
+    CurrentProperty property,
+  ) : super(StackTrace.current, property.runtimeType, property);
+
+  @override
+  String toString() =>
+      'CurrentTextControllerAlreadyInitializedException: The CurrentTextController for the property ${property?.propertyName ?? type} has already been initialized. A CurrentTextController can only be initialized once per property.\nStack: $stack';
+}
+
+/// Thrown when a CurrentTextController is used before it has been initialized with a CurrentProperty via initState.
+class CurrentTextControllerNotInitializedException<T>
+    extends CurrentTextControllerException {
+  CurrentTextControllerNotInitializedException()
+      : super(StackTrace.current, CurrentTextController<T>, null);
+
+  @override
+  String toString() =>
+      'CurrentTextControllerNotInitializedException: The CurrentTextController has not been initialized. You must initialize this controller inside the initCurrentControllers function. See CurrentTextControllersLifecycleMixin.\n\nStack: $stack';
 }

--- a/lib/src/current_int_property.dart
+++ b/lib/src/current_int_property.dart
@@ -1,5 +1,23 @@
 part of 'current_property.dart';
 
+E _normalizeResult<E extends num>(
+  num result,
+  String? propertyName,
+  Type propertyType,
+) {
+  if (result is E) {
+    return result;
+  }
+
+  throw CurrentIntPropertyInvalidArithmaticException(
+    StackTrace.current,
+    propertyName,
+    propertyType,
+    attemptedType: E,
+    resultType: result.runtimeType,
+  );
+}
+
 /// An [CurrentProperty] with similar characteristics of dart [int] objects
 ///
 /// The underlying value cannot be null. For a nullable int current property,
@@ -56,6 +74,11 @@ class CurrentIntProperty extends CurrentProperty<int> {
   /// Returns the absolute value of this integer.
   int abs() => _value.abs();
 
+  /// Adds [other] to this number and returns the numeric result.
+  ///
+  /// This does not set the value for this [CurrentIntProperty].
+  num addNumber(num other) => _value + other;
+
   /// Adds [other] to this number.
   ///
   /// This does not set the value for this [CurrentIntProperty].
@@ -63,9 +86,19 @@ class CurrentIntProperty extends CurrentProperty<int> {
   /// The result is an [int], as described by [int.+],
   /// if both this number and [other] is an integer,
   /// otherwise the result is a [double].
+  @Deprecated('Use addNumber for a predictable numeric return type.')
   E add<E extends num>(E other) {
-    return (_value + other) as E;
+    return _normalizeResult<E>(
+      addNumber(other),
+      propertyName,
+      runtimeType,
+    );
   }
+
+  /// Subtracts [other] from this number and returns the numeric result.
+  ///
+  /// This does not set the value for this [CurrentIntProperty].
+  num subtractNumber(num other) => _value - other;
 
   /// Subtracts [other] from this number.
   ///
@@ -74,8 +107,13 @@ class CurrentIntProperty extends CurrentProperty<int> {
   /// The result is an [int], as described by [int.-],
   /// if both this number and [other] is an integer,
   /// otherwise the result is a [double].
+  @Deprecated('Use subtractNumber for a predictable numeric return type.')
   E subtract<E extends num>(E other) {
-    return (_value - other) as E;
+    return _normalizeResult<E>(
+      subtractNumber(other),
+      propertyName,
+      runtimeType,
+    );
   }
 
   /// Divides this number by [other].
@@ -84,6 +122,11 @@ class CurrentIntProperty extends CurrentProperty<int> {
   double divide<E extends num>(E other) {
     return _value / other;
   }
+
+  /// Returns the modulo of this number by [other] as a numeric result.
+  ///
+  /// This does not set the value for this [CurrentIntProperty].
+  num modNumber(num other) => _value % other;
 
   /// Euclidean modulo of this number by [other].
   ///
@@ -110,9 +153,19 @@ class CurrentIntProperty extends CurrentProperty<int> {
   /// final number = CurrentIntProperty(5);
   /// print(number % 3); // 2
   /// ```
+  @Deprecated('Use modNumber for a predictable numeric return type.')
   E mod<E extends num>(E other) {
-    return (_value % other) as E;
+    return _normalizeResult<E>(
+      modNumber(other),
+      propertyName,
+      runtimeType,
+    );
   }
+
+  /// Multiplies this number by [other] and returns the numeric result.
+  ///
+  /// This does not set the value for this [CurrentIntProperty].
+  num multiplyNumber(num other) => _value * other;
 
   /// Multiplies this number by [other].
   ///
@@ -121,8 +174,13 @@ class CurrentIntProperty extends CurrentProperty<int> {
   /// The result is an [int], as described by [int.*],
   /// if both this number and [other] are integers,
   /// otherwise the result is a [double].
+  @Deprecated('Use multiplyNumber for a predictable numeric return type.')
   E multiply<E extends num>(E other) {
-    return (_value * other) as E;
+    return _normalizeResult<E>(
+      multiplyNumber(other),
+      propertyName,
+      runtimeType,
+    );
   }
 }
 
@@ -203,6 +261,17 @@ class CurrentNullableIntProperty extends CurrentProperty<int?> {
   /// Returns null if the int value is null
   int? abs() => _value?.abs();
 
+  /// Adds [other] to this number and returns the numeric result.
+  ///
+  /// This does not set the value for this [CurrentNullableIntProperty].
+  /// If the underlying value is `null` throws an [CurrentPropertyNullValueException].
+  num addNumber(num other) {
+    return isNotNull
+        ? _value! + other
+        : throw CurrentPropertyNullValueException(
+            StackTrace.current, propertyName, runtimeType);
+  }
+
   /// Adds [other] to this number.
   ///
   /// This does not set the value for this [CurrentNullableIntProperty].
@@ -212,9 +281,22 @@ class CurrentNullableIntProperty extends CurrentProperty<int?> {
   /// The result is an [int], as described by [int.+],
   /// if both this number and [other] is an integer,
   /// otherwise the result is a [double].
+  @Deprecated('Use addNumber for a predictable numeric return type.')
   E add<E extends num>(E other) {
+    return _normalizeResult<E>(
+      addNumber(other),
+      propertyName,
+      runtimeType,
+    );
+  }
+
+  /// Subtracts [other] from this number and returns the numeric result.
+  ///
+  /// This does not set the value for this [CurrentNullableIntProperty].
+  /// If the underlying value is `null` throws an [CurrentPropertyNullValueException].
+  num subtractNumber(num other) {
     return isNotNull
-        ? (_value! + other) as E
+        ? _value! - other
         : throw CurrentPropertyNullValueException(
             StackTrace.current, propertyName, runtimeType);
   }
@@ -228,11 +310,13 @@ class CurrentNullableIntProperty extends CurrentProperty<int?> {
   /// The result is an [int], as described by [int.-],
   /// if both this number and [other] is an integer,
   /// otherwise the result is a [double].
+  @Deprecated('Use subtractNumber for a predictable numeric return type.')
   E subtract<E extends num>(E other) {
-    return isNotNull
-        ? (_value! - other) as E
-        : throw CurrentPropertyNullValueException(
-            StackTrace.current, propertyName, runtimeType);
+    return _normalizeResult<E>(
+      subtractNumber(other),
+      propertyName,
+      runtimeType,
+    );
   }
 
   /// Divides this number by [other].
@@ -243,6 +327,17 @@ class CurrentNullableIntProperty extends CurrentProperty<int?> {
   double divide<E extends num>(E other) {
     return isNotNull
         ? _value! / other
+        : throw CurrentPropertyNullValueException(
+            StackTrace.current, propertyName, runtimeType);
+  }
+
+  /// Returns the modulo of this number by [other] as a numeric result.
+  ///
+  /// This does not set the value for this [CurrentNullableIntProperty].
+  /// If the underlying value is `null` throws an [CurrentPropertyNullValueException].
+  num modNumber(num other) {
+    return isNotNull
+        ? _value! % other
         : throw CurrentPropertyNullValueException(
             StackTrace.current, propertyName, runtimeType);
   }
@@ -274,9 +369,22 @@ class CurrentNullableIntProperty extends CurrentProperty<int?> {
   /// final number = CurrentNullableIntProperty(5);
   /// print(number % 3); // 2
   /// ```
+  @Deprecated('Use modNumber for a predictable numeric return type.')
   E mod<E extends num>(E other) {
+    return _normalizeResult<E>(
+      modNumber(other),
+      propertyName,
+      runtimeType,
+    );
+  }
+
+  /// Multiplies this number by [other] and returns the numeric result.
+  ///
+  /// This does not set the value for this [CurrentNullableIntProperty].
+  /// If the underlying value is `null` throws an [CurrentPropertyNullValueException].
+  num multiplyNumber(num other) {
     return isNotNull
-        ? (_value! % other) as E
+        ? _value! * other
         : throw CurrentPropertyNullValueException(
             StackTrace.current, propertyName, runtimeType);
   }
@@ -290,10 +398,12 @@ class CurrentNullableIntProperty extends CurrentProperty<int?> {
   /// otherwise the result is a [double].
   ///
   /// If the underlying value is `null` throws an [CurrentPropertyNullValueException].
+  @Deprecated('Use multiplyNumber for a predictable numeric return type.')
   E multiply<E extends num>(E other) {
-    return isNotNull
-        ? (_value! * other) as E
-        : throw CurrentPropertyNullValueException(
-            StackTrace.current, propertyName, runtimeType);
+    return _normalizeResult<E>(
+      multiplyNumber(other),
+      propertyName,
+      runtimeType,
+    );
   }
 }

--- a/lib/src/current_list_property.dart
+++ b/lib/src/current_list_property.dart
@@ -167,7 +167,13 @@ class CurrentListProperty<T> extends CurrentProperty<List<T>> {
     _value.add(value);
 
     if (notifyChanges) {
-      viewModel.notifyChanges([CurrentStateChanged.addedToList(value)]);
+      viewModel.notifyChanges([
+        CurrentStateChanged.addedToList(
+          value,
+          propertyName: propertyName,
+          sourceHashCode: sourceHashCode,
+        )
+      ]);
     }
   }
 
@@ -182,10 +188,17 @@ class CurrentListProperty<T> extends CurrentProperty<List<T>> {
   /// print(numbers); // [1, 2, 3, 4, 5, 6]
   /// ```
   void addAll(Iterable<T> values, {bool notifyChanges = true}) {
-    _value.addAll(values);
+    final addedValues = List<T>.from(values);
+    _value.addAll(addedValues);
 
     if (notifyChanges) {
-      viewModel.notifyChanges([CurrentStateChanged.addedAllToList(values)]);
+      viewModel.notifyChanges([
+        CurrentStateChanged.addedAllToList(
+          addedValues,
+          propertyName: propertyName,
+          sourceHashCode: sourceHashCode,
+        )
+      ]);
     }
   }
 
@@ -207,8 +220,14 @@ class CurrentListProperty<T> extends CurrentProperty<List<T>> {
     _value.insert(index, element);
 
     if (notifyChanges) {
-      viewModel
-          .notifyChanges([CurrentStateChanged.insertIntoList(index, value)]);
+      viewModel.notifyChanges([
+        CurrentStateChanged.insertIntoList(
+          index,
+          element,
+          propertyName: propertyName,
+          sourceHashCode: sourceHashCode,
+        )
+      ]);
     }
   }
 
@@ -224,11 +243,18 @@ class CurrentListProperty<T> extends CurrentProperty<List<T>> {
   /// print(numbers); // [1, 2, 10, 11, 12, 3, 4]
   /// ```
   void insertAll(int index, Iterable<T> values, {bool notifyChanges = true}) {
-    _value.insertAll(index, values);
+    final insertedValues = List<T>.from(values);
+    _value.insertAll(index, insertedValues);
 
     if (notifyChanges) {
-      viewModel.notifyChanges(
-          [CurrentStateChanged.insertAllIntoList(index, values)]);
+      viewModel.notifyChanges([
+        CurrentStateChanged.insertAllIntoList(
+          index,
+          insertedValues,
+          propertyName: propertyName,
+          sourceHashCode: sourceHashCode,
+        )
+      ]);
     }
   }
 
@@ -242,11 +268,19 @@ class CurrentListProperty<T> extends CurrentProperty<List<T>> {
   /// print(numbers); // [1, 2, 3, 4, 10, 11, 12]
   /// ```
   void insertAllAtEnd(Iterable<T> values, {bool notifyChanges = true}) {
-    _value.insertAll(_value.length, values);
+    final insertIndex = _value.length;
+    final insertedValues = List<T>.from(values);
+    _value.insertAll(insertIndex, insertedValues);
 
     if (notifyChanges) {
-      viewModel.notifyChanges(
-          [CurrentStateChanged.insertAllIntoList(_value.length, values)]);
+      viewModel.notifyChanges([
+        CurrentStateChanged.insertAllIntoList(
+          insertIndex,
+          insertedValues,
+          propertyName: propertyName,
+          sourceHashCode: sourceHashCode,
+        )
+      ]);
     }
   }
 
@@ -296,7 +330,13 @@ class CurrentListProperty<T> extends CurrentProperty<List<T>> {
     final wasRemoved = _value.remove(value);
 
     if (notifyChanges && wasRemoved) {
-      viewModel.notifyChanges([CurrentStateChanged.removedFromList(value)]);
+      viewModel.notifyChanges([
+        CurrentStateChanged.removedFromList(
+          value,
+          propertyName: propertyName,
+          sourceHashCode: sourceHashCode,
+        )
+      ]);
     }
 
     return wasRemoved;
@@ -320,8 +360,13 @@ class CurrentListProperty<T> extends CurrentProperty<List<T>> {
     final removedValue = _value.removeAt(index);
 
     if (notifyChanges) {
-      viewModel
-          .notifyChanges([CurrentStateChanged.removedFromList(removedValue)]);
+      viewModel.notifyChanges([
+        CurrentStateChanged.removedFromList(
+          removedValue,
+          propertyName: propertyName,
+          sourceHashCode: sourceHashCode,
+        )
+      ]);
     }
 
     return removedValue;
@@ -338,8 +383,12 @@ class CurrentListProperty<T> extends CurrentProperty<List<T>> {
   /// print(numbers); // []
   /// ```
   void clear({bool notifyChanges = true}) {
-    final stateChangedEvent =
-        CurrentStateChanged.clearedList(_value, propertyName: propertyName);
+    final previousItems = List<T>.from(_value);
+    final stateChangedEvent = CurrentStateChanged.clearedList(
+      previousItems,
+      propertyName: propertyName,
+      sourceHashCode: sourceHashCode,
+    );
     _value.clear();
 
     if (notifyChanges) {

--- a/lib/src/current_list_property.dart
+++ b/lib/src/current_list_property.dart
@@ -9,6 +9,25 @@ class CurrentListProperty<T> extends CurrentProperty<List<T>> {
     _originalValue = List<T>.from(value);
   }
 
+  @override
+  bool hasValueChanged(List<T> currentValue, List<T> originalValue) {
+    if (identical(currentValue, originalValue)) {
+      return false;
+    }
+
+    if (currentValue.length != originalValue.length) {
+      return true;
+    }
+
+    for (var index = 0; index < currentValue.length; index++) {
+      if (currentValue[index] != originalValue[index]) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
   ///Factory constructor for initializing an [CurrentListProperty] to an empty [List].
   ///
   ///See [CurrentProperty] for [propertyName] usages.

--- a/lib/src/current_map_property.dart
+++ b/lib/src/current_map_property.dart
@@ -9,6 +9,26 @@ class CurrentMapProperty<K, V> extends CurrentProperty<Map<K, V>> {
     _originalValue = Map<K, V>.from(value);
   }
 
+  @override
+  bool hasValueChanged(Map<K, V> currentValue, Map<K, V> originalValue) {
+    if (identical(currentValue, originalValue)) {
+      return false;
+    }
+
+    if (currentValue.length != originalValue.length) {
+      return true;
+    }
+
+    for (final entry in currentValue.entries) {
+      if (!originalValue.containsKey(entry.key) ||
+          originalValue[entry.key] != entry.value) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
   ///Factory constructor for initializing an [CurrentMapProperty] to an empty [Map].
   ///
   ///See [CurrentProperty] for [propertyName] usages.

--- a/lib/src/current_map_property.dart
+++ b/lib/src/current_map_property.dart
@@ -82,11 +82,16 @@ class CurrentMapProperty<K, V> extends CurrentProperty<Map<K, V>> {
   ///
   /// If a key of [other] is already in this map, its value is overwritten.
   void addAll(Map<K, V> other, {bool notifyChanges = true}) {
-    _value.addAll(other);
+    final addedMap = Map<K, V>.from(other);
+    _value.addAll(addedMap);
 
     if (notifyChanges) {
       viewModel.notifyChanges([
-        CurrentStateChanged.addedMapToMap(other, propertyName: propertyName)
+        CurrentStateChanged.addedMapToMap(
+          addedMap,
+          propertyName: propertyName,
+          sourceHashCode: sourceHashCode,
+        )
       ]);
     }
   }
@@ -101,7 +106,7 @@ class CurrentMapProperty<K, V> extends CurrentProperty<Map<K, V>> {
     if (notifyChanges) {
       viewModel.notifyChanges([
         CurrentStateChanged.addedToMap(entry.key, entry.value,
-            propertyName: propertyName)
+            propertyName: propertyName, sourceHashCode: sourceHashCode)
       ]);
     }
   }
@@ -126,12 +131,13 @@ class CurrentMapProperty<K, V> extends CurrentProperty<Map<K, V>> {
   /// ```
   void addEntries(Iterable<MapEntry<K, V>> entries,
       {bool notifyChanges = true}) {
-    _value.addEntries(entries);
+    final addedEntries = List<MapEntry<K, V>>.from(entries);
+    _value.addEntries(addedEntries);
 
     if (notifyChanges) {
       viewModel.notifyChanges([
-        CurrentStateChanged.addedEntriesToMap(entries,
-            propertyName: propertyName)
+        CurrentStateChanged.addedEntriesToMap(addedEntries,
+            propertyName: propertyName, sourceHashCode: sourceHashCode)
       ]);
     }
   }
@@ -145,7 +151,8 @@ class CurrentMapProperty<K, V> extends CurrentProperty<Map<K, V>> {
 
     if (notifyChanges) {
       viewModel.notifyChanges([
-        CurrentStateChanged.addedToMap(key, value, propertyName: propertyName)
+        CurrentStateChanged.addedToMap(key, value,
+            propertyName: propertyName, sourceHashCode: sourceHashCode)
       ]);
     }
   }
@@ -186,6 +193,7 @@ class CurrentMapProperty<K, V> extends CurrentProperty<Map<K, V>> {
           originalValue,
           updatedValue,
           propertyName: propertyName,
+          sourceHashCode: sourceHashCode,
         )
       ]);
     }
@@ -214,6 +222,7 @@ class CurrentMapProperty<K, V> extends CurrentProperty<Map<K, V>> {
         previousValue,
         updatedValue,
         propertyName: propertyName,
+        sourceHashCode: sourceHashCode,
       ));
       return updatedValue;
     });
@@ -244,6 +253,7 @@ class CurrentMapProperty<K, V> extends CurrentProperty<Map<K, V>> {
           key,
           removedValue,
           propertyName: propertyName,
+          sourceHashCode: sourceHashCode,
         )
       ]);
     }
@@ -269,6 +279,7 @@ class CurrentMapProperty<K, V> extends CurrentProperty<Map<K, V>> {
           key,
           value,
           propertyName: propertyName,
+          sourceHashCode: sourceHashCode,
         ));
       }
 
@@ -288,8 +299,13 @@ class CurrentMapProperty<K, V> extends CurrentProperty<Map<K, V>> {
   /// planets.clear(); // {}
   /// ```
   void clear({bool notifyChanges = true}) {
-    final stateChangedEvent =
-        CurrentStateChanged(<K, V>{}, _value, propertyName: propertyName);
+    final previousItems = Map<K, V>.from(_value);
+    final stateChangedEvent = CurrentStateChanged(
+      <K, V>{},
+      previousItems,
+      propertyName: propertyName,
+      sourceHashCode: sourceHashCode,
+    );
 
     _value.clear();
 

--- a/lib/src/current_property.dart
+++ b/lib/src/current_property.dart
@@ -52,6 +52,8 @@ abstract class CurrentValue<T> {
 class CurrentProperty<T> implements CurrentValue<T> {
   String? propertyName;
 
+  final int sourceHashCode = identityHashCode(Object());
+
   final bool isPrimitiveType;
 
   late T _originalValue;
@@ -505,7 +507,7 @@ class CurrentProperty<T> implements CurrentValue<T> {
           value,
           previousValue,
           propertyName: propertyName,
-          sourceHashCode: hashCode,
+          sourceHashCode: sourceHashCode,
         )
       ]);
     }
@@ -564,7 +566,7 @@ class CurrentProperty<T> implements CurrentValue<T> {
           _originalValue,
           currentValue,
           propertyName: propertyName,
-          sourceHashCode: hashCode,
+          sourceHashCode: sourceHashCode,
         )
       ]);
     }

--- a/lib/src/current_property.dart
+++ b/lib/src/current_property.dart
@@ -86,7 +86,14 @@ class CurrentProperty<T> implements CurrentValue<T> {
   /// Returns true if the value of this [CurrentProperty] is different from the [originalValue].
   ///
   /// This can be used to determine if the value has been changed since it was last reset or since the [originalValue] was last updated to the current value.
-  bool get isDirty => value != originalValue;
+  bool get isDirty => hasValueChanged(value, originalValue);
+
+  /// Determines whether the current value differs from the original value.
+  ///
+  /// Specialized property types can override this when their value semantics
+  /// differ from the default `==` comparison.
+  bool hasValueChanged(T currentValue, T originalValue) =>
+      currentValue != originalValue;
 
   CurrentViewModel? _viewModel;
 

--- a/lib/src/current_property.dart
+++ b/lib/src/current_property.dart
@@ -582,7 +582,10 @@ class CurrentProperty<T> implements CurrentValue<T> {
   @override
   String toString() => _value?.toString() ?? '';
 
-  ///Checks if [other] is equal to the [value] of this CurrentProperty
+  ///Checks if [other] is equal to the [value] of this CurrentProperty.
+  ///
+  /// This is a value-comparison convenience method and is intentionally
+  /// different from [operator ==], which uses property identity.
   ///
   ///### Usage
   ///
@@ -605,11 +608,10 @@ class CurrentProperty<T> implements CurrentValue<T> {
   }
 
   @override
-  // ignore: non_nullable_equals_parameter
-  bool operator ==(dynamic other) => equals(other);
+  bool operator ==(Object other) => identical(this, other);
 
   @override
-  int get hashCode => _value.hashCode;
+  int get hashCode => sourceHashCode;
 }
 
 ///Short hand helper function for initializing an [CurrentProperty].

--- a/lib/src/current_property.dart
+++ b/lib/src/current_property.dart
@@ -501,7 +501,12 @@ class CurrentProperty<T> implements CurrentValue<T> {
     _value = value;
     if (notifyChange && previousValue != value) {
       viewModel.notifyChanges([
-        CurrentStateChanged(value, previousValue, propertyName: propertyName)
+        CurrentStateChanged(
+          value,
+          previousValue,
+          propertyName: propertyName,
+          sourceHashCode: hashCode,
+        )
       ]);
     }
 
@@ -559,6 +564,7 @@ class CurrentProperty<T> implements CurrentValue<T> {
           _originalValue,
           currentValue,
           propertyName: propertyName,
+          sourceHashCode: hashCode,
         )
       ]);
     }

--- a/lib/src/current_text_controller.dart
+++ b/lib/src/current_text_controller.dart
@@ -379,8 +379,7 @@ final class CurrentTextController<T> extends TextEditingController {
       fromString: fromString,
       asString: asString ??
           (propertyValue) =>
-              (propertyValue as DateTime?)?.toIso8601String() ??
-              'Unparsable Date',
+              (propertyValue as DateTime?)?.toIso8601String() ?? '',
       defaultValue: defaultValue,
     );
   }

--- a/lib/src/current_text_controller.dart
+++ b/lib/src/current_text_controller.dart
@@ -45,9 +45,20 @@ import 'package:flutter/material.dart';
 ///
 ///   @override
 ///   void bindCurrentControllers() {
-///     nameController.bindString(context: context, property: viewModel.name);
-///     ageController.bindInteger(context: context, property: viewModel.age, defaultValue: 0);
-///     departureDateController.bindDate(context: context, property: viewModel.departureDate);
+///     nameController.bindString(
+///       property: viewModel.name,
+///       lifecycleProvider: this,
+///     );
+///     ageController.bindInt(
+///       property: viewModel.age,
+///       lifecycleProvider: this,
+///       defaultValue: 0,
+///     );
+///     departureDateController.bindDateTime(
+///       property: viewModel.departureDate,
+///       lifecycleProvider: this,
+///       fromString: DateTime.parse,
+///     );
 ///   }
 ///
 ///   @override
@@ -74,32 +85,46 @@ import 'package:flutter/material.dart';
 final class CurrentTextController<T> extends TextEditingController {
   /// The [CurrentProperty] that this controller is bound to. This will be set during initialization in the [bind] method.
   ///
-  late final CurrentProperty<T?> property;
+  CurrentProperty<T?>? _property;
+  CurrentProperty<T?> get property {
+    final boundProperty = _property;
+
+    if (boundProperty == null) {
+      throw CurrentTextControllerNotInitializedException<T>();
+    }
+
+    return boundProperty;
+  }
 
   /// A function that parses a string into the type of the [CurrentProperty]. This is used to update the property's value when the text changes. This will be set during initialization in the [bind] method. If the [CurrentProperty] is of type String, this function can be omitted and the controller will simply use the text as the property's value.
   ///
-  late final T Function(String text)? fromString;
+  T Function(String text)? _fromString;
+  T Function(String text)? get fromString => _fromString;
 
   /// A function that converts the [CurrentProperty]'s value into a string for display in the text field. This will be set during initialization in the [bind] method. If not provided, it will default to using the property's value's toString() method, or an empty string if the property's value is null.
   ///
-  late final String? Function(T? propertyValue)? asString;
+  String? Function(T? propertyValue)? _asString;
+  String? Function(T? propertyValue)? get asString => _asString;
 
   /// An optional default value to use when parsing the text if the [fromString] function fails to parse the text. This is only used for non-String properties. If the [CurrentProperty] is of type String, this can be omitted since parsing will not be performed.
   ///
-  late final StreamSubscription _subscription;
+  StreamSubscription? _subscription;
 
   /// An optional default value to use when parsing the text if the [fromString] function fails to parse the text. This is only used for non-String properties. If the [CurrentProperty] is of type String, this can be omitted since parsing will not be performed.
   ///
-  T? defaultValue;
+  T? _defaultValue;
+  T? get defaultValue => _defaultValue;
+
+  bool get _isNullable => null is T;
+
+  bool _hasDefaultValue = false;
+  bool _isSyncingText = false;
+  bool _treatTextAsStringValue = false;
 
   CurrentTextControllersLifecycleMixin? _lifecycleProvider;
 
   CurrentTextController._() {
-    addListener(() {
-      if (_lifecycleProvider == null) {
-        throw CurrentTextControllerNotInitializedException<T>();
-      }
-    });
+    addListener(_handleTextChanged);
   }
 
   /// Factory constructor to create a CurrentTextController for a String property.
@@ -160,9 +185,11 @@ final class CurrentTextController<T> extends TextEditingController {
   ///
   /// If the CurrentProperty is not of type String, you must provide a fromString function to parse the text into the property's type.
   ///
-  /// If it is a Non-Nullable non-String type,
-  /// you should also provide a [defaultValue]. In the case that [fromString] fails to parse the text, the [defaultValue] will be used instead. If a [defaultValue] is not provided
-  /// and parsing fails, an exception will be thrown.
+  /// If it is a Non-Nullable non-String type, you can optionally provide a
+  /// [defaultValue]. When the user clears the text field, the controller will
+  /// use that explicit default value instead of leaving the property unchanged.
+  /// Invalid non-empty text does not throw and does not update the property
+  /// until parsing succeeds.
   ///
   /// If the CurrentProperty is of type String, you can omit the fromString function and the controller will simply use the text as the property's value. In this case, providing a defaultValue is not necessary since parsing will not be performed.
   ///
@@ -175,34 +202,40 @@ final class CurrentTextController<T> extends TextEditingController {
     String? Function(T? propertyValue)? asString,
     T? defaultValue,
   }) {
-    _lifecycleProvider = lifecycleProvider;
+    final treatTextAsStringValue = _isStringProperty(property);
 
-    if (_lifecycleProvider?.controllersInitialized ?? false) {
-      throw CurrentTextControllerAlreadyInitializedException(property);
+    if (!treatTextAsStringValue && fromString == null) {
+      throw ArgumentError.value(
+        fromString,
+        'fromString',
+        'A fromString function is required for non-String CurrentTextController bindings.',
+      );
     }
 
-    this.property = property;
-    this.fromString = fromString;
-    this.asString = asString;
+    if (_matchesBinding(
+      property: property,
+      lifecycleProvider: lifecycleProvider,
+      fromString: fromString,
+      asString: asString,
+      defaultValue: defaultValue,
+      treatTextAsStringValue: treatTextAsStringValue,
+    )) {
+      return;
+    }
 
-    addListener(() {
-      final value = _tryParseText(text);
+    _subscription?.cancel();
 
-      if (value == property.value) {
-        return;
-      }
+    _property = property;
+    _fromString = fromString;
+    _asString = asString;
+    _defaultValue = defaultValue;
+    _hasDefaultValue = !_isNullable && defaultValue != null;
+    _treatTextAsStringValue = treatTextAsStringValue;
+    _lifecycleProvider = lifecycleProvider;
 
-      property.set(value);
-    });
-
-    _subscription = property.viewModel.addStateChangedListener(
-      (event) {
-        if (event != null) {
-          _setText();
-        }
-      },
-      filter: (CurrentStateChanged? event) =>
-          event?.sourceHashCode == property.hashCode,
+    _subscription = property.viewModel.addStateChangedListener<CurrentStateChanged>(
+      (_) => _setText(),
+      filter: (event) => event.sourceHashCode == property.sourceHashCode,
     );
 
     _setText();
@@ -220,6 +253,7 @@ final class CurrentTextController<T> extends TextEditingController {
         CurrentProperty property) {
       final validTypes = [
         CurrentProperty<String>,
+        CurrentProperty<String?>,
         CurrentStringProperty,
         CurrentNullableStringProperty
       ];
@@ -228,6 +262,7 @@ final class CurrentTextController<T> extends TextEditingController {
       // guarding against Darts reified generics. Simply checking via `validTypes.any((type) => property.runtimeType == type)`
       // is not guaranteed to behave correctly due to possible type erasure.
       if (property is! CurrentProperty<String> &&
+          property is! CurrentProperty<String?> &&
           property is! CurrentStringProperty &&
           property is! CurrentNullableStringProperty) {
         return (false, validTypes);
@@ -264,6 +299,7 @@ final class CurrentTextController<T> extends TextEditingController {
         CurrentProperty property) {
       final validTypes = [
         CurrentProperty<int>,
+        CurrentProperty<int?>,
         CurrentIntProperty,
         CurrentNullableIntProperty
       ];
@@ -272,6 +308,7 @@ final class CurrentTextController<T> extends TextEditingController {
       // guarding against Darts reified generics. Simply checking via `validTypes.any((type) => property.runtimeType == type)`
       // is not guaranteed to behave correctly due to possible type erasure.
       if (property is! CurrentProperty<int> &&
+          property is! CurrentProperty<int?> &&
           property is! CurrentIntProperty &&
           property is! CurrentNullableIntProperty) {
         return (false, validTypes);
@@ -290,10 +327,9 @@ final class CurrentTextController<T> extends TextEditingController {
     bind(
       property: property,
       lifecycleProvider: lifecycleProvider,
-      fromString:
-          fromString ?? (text) => (int.tryParse(text) ?? defaultValue) as T,
+      fromString: fromString ?? (text) => int.parse(text) as T,
       asString: asString,
-      defaultValue: defaultValue as T,
+      defaultValue: defaultValue,
     );
   }
 
@@ -311,6 +347,7 @@ final class CurrentTextController<T> extends TextEditingController {
         CurrentProperty property) {
       final validTypes = [
         CurrentProperty<DateTime>,
+        CurrentProperty<DateTime?>,
         CurrentDateTimeProperty,
         CurrentNullableDateTimeProperty
       ];
@@ -319,6 +356,7 @@ final class CurrentTextController<T> extends TextEditingController {
       // guarding against Darts reified generics. Simply checking via `validTypes.any((type) => property.runtimeType == type)`
       // is not guaranteed to behave correctly due to possible type erasure.
       if (property is! CurrentProperty<DateTime> &&
+          property is! CurrentProperty<DateTime?> &&
           property is! CurrentDateTimeProperty &&
           property is! CurrentNullableDateTimeProperty) {
         return (false, validTypes);
@@ -342,38 +380,122 @@ final class CurrentTextController<T> extends TextEditingController {
           (propertyValue) =>
               (propertyValue as DateTime?)?.toIso8601String() ??
               'Unparsable Date',
-      defaultValue: defaultValue as T,
+      defaultValue: defaultValue,
     );
   }
 
   void _setText() {
-    final value =
-        asString?.call(property.value) ?? property.value?.toString() ?? '';
+    final boundProperty = _property;
 
-    if (value != text) {
-      text = value;
+    if (boundProperty == null) {
+      return;
+    }
+
+    final nextText =
+        _asString?.call(boundProperty.value) ?? boundProperty.value?.toString() ?? '';
+
+    if (nextText == text) {
+      return;
+    }
+
+    _isSyncingText = true;
+    try {
+      value = TextEditingValue(
+        text: nextText,
+        selection: TextSelection.collapsed(offset: nextText.length),
+      );
+    } finally {
+      _isSyncingText = false;
     }
   }
 
-  T? _tryParseText(String text) {
-    try {
-      return fromString?.call(text) ?? defaultValue ?? text as T;
-    } catch (_) {
-      throw Exception(
-        'Failed to parse and set CurrentProperty "${property.propertyName ?? property.runtimeType}" with value "$text". Did you provide a fromString function or provide a defaultValue?',
-      );
+  void _handleTextChanged() {
+    final boundProperty = _property;
+
+    if (_isSyncingText || boundProperty == null) {
+      return;
     }
+
+    final parseResult = _tryParseText(text);
+
+    if (!parseResult.shouldUpdate || parseResult.value == boundProperty.value) {
+      return;
+    }
+
+    boundProperty.set(parseResult.value);
+  }
+
+  ({bool shouldUpdate, T? value}) _tryParseText(String text) {
+    if (_treatTextAsStringValue) {
+      if (text.isEmpty && _isNullable) {
+        return (shouldUpdate: true, value: null);
+      }
+
+      return (shouldUpdate: true, value: text as T);
+    }
+
+    if (text.isEmpty) {
+      if (_isNullable) {
+        return (shouldUpdate: true, value: null);
+      }
+
+      if (_hasDefaultValue) {
+        return (shouldUpdate: true, value: _defaultValue);
+      }
+
+      return (shouldUpdate: false, value: null);
+    }
+
+    final parser = _fromString;
+
+    if (parser == null) {
+      return (shouldUpdate: false, value: null);
+    }
+
+    try {
+      return (shouldUpdate: true, value: parser(text));
+    } catch (_) {
+      return (shouldUpdate: false, value: null);
+    }
+  }
+
+  bool _isStringProperty(CurrentProperty property) {
+    return property is CurrentProperty<String> ||
+        property is CurrentProperty<String?> ||
+        property is CurrentStringProperty ||
+        property is CurrentNullableStringProperty;
+  }
+
+  bool _matchesBinding({
+    required CurrentProperty<T?> property,
+    required CurrentTextControllersLifecycleMixin lifecycleProvider,
+    required T Function(String text)? fromString,
+    required String? Function(T? propertyValue)? asString,
+    required T? defaultValue,
+    required bool treatTextAsStringValue,
+  }) {
+    return identical(_property, property) &&
+        identical(_lifecycleProvider, lifecycleProvider) &&
+        identical(_fromString, fromString) &&
+        identical(_asString, asString) &&
+        _defaultValue == defaultValue &&
+        _hasDefaultValue == (!_isNullable && defaultValue != null) &&
+        _treatTextAsStringValue == treatTextAsStringValue;
   }
 
   @override
   void dispose() {
-    _subscription.cancel();
+    _subscription?.cancel();
+    _subscription = null;
     super.dispose();
   }
 }
 
 /// A mixin for managing the lifecycle of [CurrentTextController]s in a [CurrentState].
-/// This mixin ensures that the controllers are only initialized once.
+///
+/// This mixin initializes controllers on the first dependency pass and re-runs
+/// [bindCurrentControllers] when the widget updates so controllers can rebind
+/// to new properties when needed.
 ///
 /// Must implement [bindCurrentControllers]. This is where you should initialize your [CurrentTextController]s.
 mixin CurrentTextControllersLifecycleMixin<TWidget extends CurrentWidget,
@@ -385,12 +507,23 @@ mixin CurrentTextControllersLifecycleMixin<TWidget extends CurrentWidget,
 
   void bindCurrentControllers();
 
+  void _bindOrRebindControllers() {
+    bindCurrentControllers();
+    _initializedControllers = true;
+  }
+
   @override
   void didChangeDependencies() {
-    if (!controllersInitialized) {
-      bindCurrentControllers();
-      _initializedControllers = true;
-    }
     super.didChangeDependencies();
+
+    if (!controllersInitialized) {
+      _bindOrRebindControllers();
+    }
+  }
+
+  @override
+  void didUpdateWidget(covariant TWidget oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    _bindOrRebindControllers();
   }
 }

--- a/lib/src/current_text_controller.dart
+++ b/lib/src/current_text_controller.dart
@@ -233,7 +233,8 @@ final class CurrentTextController<T> extends TextEditingController {
     _treatTextAsStringValue = treatTextAsStringValue;
     _lifecycleProvider = lifecycleProvider;
 
-    _subscription = property.viewModel.addStateChangedListener<CurrentStateChanged>(
+    _subscription =
+        property.viewModel.addStateChangedListener<CurrentStateChanged>(
       (_) => _setText(),
       filter: (event) => event.sourceHashCode == property.sourceHashCode,
     );
@@ -384,15 +385,16 @@ final class CurrentTextController<T> extends TextEditingController {
     );
   }
 
-  void _setText() {
+  void _setText({bool selectAll = false}) {
     final boundProperty = _property;
 
     if (boundProperty == null) {
       return;
     }
 
-    final nextText =
-        _asString?.call(boundProperty.value) ?? boundProperty.value?.toString() ?? '';
+    final nextText = _asString?.call(boundProperty.value) ??
+        boundProperty.value?.toString() ??
+        '';
 
     if (nextText == text) {
       return;
@@ -402,7 +404,9 @@ final class CurrentTextController<T> extends TextEditingController {
     try {
       value = TextEditingValue(
         text: nextText,
-        selection: TextSelection.collapsed(offset: nextText.length),
+        selection: selectAll && nextText.isNotEmpty
+            ? TextSelection(baseOffset: 0, extentOffset: nextText.length)
+            : TextSelection.collapsed(offset: nextText.length),
       );
     } finally {
       _isSyncingText = false;
@@ -417,6 +421,14 @@ final class CurrentTextController<T> extends TextEditingController {
     }
 
     final parseResult = _tryParseText(text);
+
+    if (!parseResult.shouldUpdate &&
+        text.isEmpty &&
+        !_isNullable &&
+        !_hasDefaultValue) {
+      _setText(selectAll: true);
+      return;
+    }
 
     if (!parseResult.shouldUpdate || parseResult.value == boundProperty.value) {
       return;

--- a/lib/src/current_text_controller.dart
+++ b/lib/src/current_text_controller.dart
@@ -1,0 +1,396 @@
+import 'dart:async';
+
+import 'package:current/current.dart';
+import 'package:current/src/current_exceptions.dart';
+import 'package:flutter/material.dart';
+
+/// A TextEditingController that is bound to a CurrentProperty.
+///
+/// Should apply the [CurrentTextControllersLifecycleMixin] mixin to the State of your Widget to manage the lifecycle of the controller and ensure it is properly disposed of.
+///
+/// Use the factory contructors to create a new instance.
+///
+/// [CurrentTextController.string], [CurrentTextController.nullableString],
+///
+/// [CurrentTextController.integer], [CurrentTextController.nullableInteger],
+///
+/// [CurrentTextController.date], and [CurrentTextController.nullableDate]
+///
+/// These are provided for convenience when working with common types, but you can also use [CurrentTextController.of] to create a controller for any type.
+///
+/// When using [CurrentTextController.of], you must provide the fromString and [asString] functions in the [bind] method to specify how to parse the text into the property's type and how to display the property's value as text.
+///
+/// It listens for changes to the property and updates the text accordingly, and also updates the property when the text changes.
+/// You MUST call [bind] to configure the controller. If you do not, the controller will simply act as a normal [TextEditingController].
+///
+/// Example usage:
+///
+///
+/// ```dart
+///
+/// class MyWidgetViewModel extends CurrentViewModel {
+///   final name = CurrentStringProperty();
+///   final age = CurrentIntProperty();
+///   final departureDate = CurrentNullableDateTimeProperty();
+///
+///   @override
+///   Iterable<CurrentProperty> get currentProps => [name, age, departureDate];
+/// }
+///
+/// class _MyWidgetState extends CurrentState<_MyWidgetState, MyWidgetViewModel> with CurrentTextControllersLifecycleMixin {
+///
+///   final nameController = CurrentTextController.string();
+///   final ageController = CurrentTextController.integer();
+///   final departureDateController = CurrentTextController.nullableDate();
+///
+///   @override
+///   void bindCurrentControllers() {
+///     nameController.bindString(context: context, property: viewModel.name);
+///     ageController.bindInteger(context: context, property: viewModel.age, defaultValue: 0);
+///     departureDateController.bindDate(context: context, property: viewModel.departureDate);
+///   }
+///
+///   @override
+///   void dispose() {
+///     nameController.dispose();
+///     ageController.dispose();
+///     departureDateController.dispose();
+///     super.dispose();
+///   }
+///
+///   @override
+///   Widget build(BuildContext context) {
+///     return Column(
+///       children: [
+///         TextField(controller: nameController),
+///         TextField(controller: ageController),
+///         TextField(controller: departureDateController),
+///       ],
+///     );
+///   }
+/// }
+/// ```
+///
+final class CurrentTextController<T> extends TextEditingController {
+  /// The [CurrentProperty] that this controller is bound to. This will be set during initialization in the [bind] method.
+  ///
+  late final CurrentProperty<T?> property;
+
+  /// A function that parses a string into the type of the [CurrentProperty]. This is used to update the property's value when the text changes. This will be set during initialization in the [bind] method. If the [CurrentProperty] is of type String, this function can be omitted and the controller will simply use the text as the property's value.
+  ///
+  late final T Function(String text)? fromString;
+
+  /// A function that converts the [CurrentProperty]'s value into a string for display in the text field. This will be set during initialization in the [bind] method. If not provided, it will default to using the property's value's toString() method, or an empty string if the property's value is null.
+  ///
+  late final String? Function(T? propertyValue)? asString;
+
+  /// An optional default value to use when parsing the text if the [fromString] function fails to parse the text. This is only used for non-String properties. If the [CurrentProperty] is of type String, this can be omitted since parsing will not be performed.
+  ///
+  late final StreamSubscription _subscription;
+
+  /// An optional default value to use when parsing the text if the [fromString] function fails to parse the text. This is only used for non-String properties. If the [CurrentProperty] is of type String, this can be omitted since parsing will not be performed.
+  ///
+  T? defaultValue;
+
+  CurrentTextControllersLifecycleMixin? _lifecycleProvider;
+
+  CurrentTextController._() {
+    addListener(() {
+      if (_lifecycleProvider == null) {
+        throw CurrentTextControllerNotInitializedException<T>();
+      }
+    });
+  }
+
+  /// Factory constructor to create a CurrentTextController for a String property.
+  ///
+  /// **IMPORTANT**: You still must call either the [bind] or the [bindString]
+  /// in the [CurrentTextControllersLifecycleMixin.bindCurrentControllers] method to initialize the controller and bind it to a CurrentProperty.
+  /// The factory constructor only creates an instance of the controller, but does not configure it in any way.
+  static CurrentTextController<String> string() =>
+      CurrentTextController<String>._();
+
+  /// Factory constructor to create a CurrentTextController for a nullable String  property.
+  ///
+  /// **IMPORTANT**: You still must call either the [bind] or the [bindString]
+  /// in the [CurrentTextControllersLifecycleMixin.bindCurrentControllers] method to initialize the controller and bind it to a CurrentProperty.
+  /// The factory constructor only creates an instance of the controller, but does not configure it in any way.
+  static CurrentTextController<String?> nullableString() =>
+      CurrentTextController<String?>._();
+
+  /// Factory constructor to create a CurrentTextController for an integer property.
+  ///
+  /// **IMPORTANT**: You still must call either the [bind] or the [bindInt]
+  /// in the [CurrentTextControllersLifecycleMixin.bindCurrentControllers] method to initialize the controller and bind it to a CurrentProperty.
+  /// The factory constructor only creates an instance of the controller, but does not configure it in any way.
+  static CurrentTextController<int> integer() => CurrentTextController<int>._();
+
+  /// Factory constructor to create a CurrentTextController for a nullable integer property.
+  ///
+  /// **IMPORTANT**: You still must call either the [bind] or the [bindInt]
+  /// in the [CurrentTextControllersLifecycleMixin.bindCurrentControllers] method to initialize the controller and bind it to a CurrentProperty.
+  /// The factory constructor only creates an instance of the controller, but does not configure it in any way.
+  static CurrentTextController<int?> nullableInteger() =>
+      CurrentTextController<int?>._();
+
+  /// Factory constructor to create a CurrentTextController for a DateTime property.
+  ///
+  /// **IMPORTANT**: You still must call either the [bind] or the [bindDateTime]
+  /// in the [CurrentTextControllersLifecycleMixin.bindCurrentControllers] method to initialize the controller and bind it to a CurrentProperty.
+  /// The factory constructor only creates an instance of the controller, but does not configure it in any way.
+  static CurrentTextController<DateTime> date() =>
+      CurrentTextController<DateTime>._();
+
+  /// Factory constructor to create a CurrentTextController for a nullable DateTime property.
+  ///
+  /// **IMPORTANT**: You still must call either the [bind] or the [bindDateTime]
+  /// in the [CurrentTextControllersLifecycleMixin.bindCurrentControllers] method to initialize the controller and bind it to a CurrentProperty.
+  /// The factory constructor only creates an instance of the controller, but does not configure it in any way.
+  static CurrentTextController<DateTime?> nullableDate() =>
+      CurrentTextController<DateTime?>._();
+
+  /// Factory constructor to create a CurrentTextController for a type specified by the generic parameter [T].
+  ///
+  /// **IMPORTANT**: You still must call either the [bind]
+  /// in the [CurrentTextControllersLifecycleMixin.bindCurrentControllers] method to initialize the controller and bind it to a CurrentProperty.
+  /// The factory constructor only creates an instance of the controller, but does not configure it in any way.
+  static CurrentTextController<T> of<T>() => CurrentTextController<T>._();
+
+  /// Initializes the CurrentTextController by binding it to a CurrentProperty and providing necessary configuration for parsing and displaying the property's value.
+  ///
+  /// If the CurrentProperty is not of type String, you must provide a fromString function to parse the text into the property's type.
+  ///
+  /// If it is a Non-Nullable non-String type,
+  /// you should also provide a [defaultValue]. In the case that [fromString] fails to parse the text, the [defaultValue] will be used instead. If a [defaultValue] is not provided
+  /// and parsing fails, an exception will be thrown.
+  ///
+  /// If the CurrentProperty is of type String, you can omit the fromString function and the controller will simply use the text as the property's value. In this case, providing a defaultValue is not necessary since parsing will not be performed.
+  ///
+  /// The asString function is optional, but can be used to customize how the property's value is displayed in the text field. If not provided, it will default to using the property's value's toString() method, or an empty string if the property's value is null.
+  ///
+  void bind({
+    required CurrentProperty<T?> property,
+    required CurrentTextControllersLifecycleMixin lifecycleProvider,
+    T Function(String text)? fromString,
+    String? Function(T? propertyValue)? asString,
+    T? defaultValue,
+  }) {
+    _lifecycleProvider = lifecycleProvider;
+
+    if (_lifecycleProvider?.controllersInitialized ?? false) {
+      throw CurrentTextControllerAlreadyInitializedException(property);
+    }
+
+    this.property = property;
+    this.fromString = fromString;
+    this.asString = asString;
+
+    addListener(() {
+      final value = _tryParseText(text);
+
+      if (value == property.value) {
+        return;
+      }
+
+      property.set(value);
+    });
+
+    _subscription = property.viewModel.addStateChangedListener(
+      (event) {
+        if (event != null) {
+          _setText();
+        }
+      },
+      filter: (CurrentStateChanged? event) =>
+          event?.sourceHashCode == property.hashCode,
+    );
+
+    _setText();
+  }
+
+  /// A convenience method for initializing the controller with properties based on [CurrentProperty<String>]. This is equivalent to calling [bind] with fromString and asString configured for String properties.
+  /// If the CurrentProperty is not of type String, this method will throw an exception.
+  ///
+  void bindString({
+    required CurrentProperty<T> property,
+    required CurrentTextControllersLifecycleMixin lifecycleProvider,
+    String? Function(T? propertyValue)? asString,
+  }) {
+    (bool isValidType, List<Type> validTypes) validateType(
+        CurrentProperty property) {
+      final validTypes = [
+        CurrentProperty<String>,
+        CurrentStringProperty,
+        CurrentNullableStringProperty
+      ];
+
+      // This is done in a verbose way, duplicating the list (unfortunately) to ensure type check safety,
+      // guarding against Darts reified generics. Simply checking via `validTypes.any((type) => property.runtimeType == type)`
+      // is not guaranteed to behave correctly due to possible type erasure.
+      if (property is! CurrentProperty<String> &&
+          property is! CurrentStringProperty &&
+          property is! CurrentNullableStringProperty) {
+        return (false, validTypes);
+      }
+      return (true, validTypes);
+    }
+
+    if (validateType(property) case (false, final validTypes)) {
+      throw CurrentTextControllerCurrentPropertyTypeException(
+        property,
+        'stringController',
+        validTypes,
+      );
+    }
+
+    bind(
+      property: property,
+      lifecycleProvider: lifecycleProvider,
+      asString: asString,
+    );
+  }
+
+  /// A convenience method for initializing the controller with properties based on [CurrentProperty<int>]. This is equivalent to calling [bind] with fromString and asString configured for int properties.
+  /// If the CurrentProperty is not of type int, this method will throw an exception.
+  ///
+  void bindInt({
+    required CurrentProperty<T> property,
+    required CurrentTextControllersLifecycleMixin lifecycleProvider,
+    T Function(String text)? fromString,
+    String? Function(T? propertyValue)? asString,
+    T? defaultValue,
+  }) {
+    (bool isValidType, List<Type> validTypes) validateType(
+        CurrentProperty property) {
+      final validTypes = [
+        CurrentProperty<int>,
+        CurrentIntProperty,
+        CurrentNullableIntProperty
+      ];
+
+      // This is done in a verbose way, duplicating the list (unfortunately) to ensure type check safety,
+      // guarding against Darts reified generics. Simply checking via `validTypes.any((type) => property.runtimeType == type)`
+      // is not guaranteed to behave correctly due to possible type erasure.
+      if (property is! CurrentProperty<int> &&
+          property is! CurrentIntProperty &&
+          property is! CurrentNullableIntProperty) {
+        return (false, validTypes);
+      }
+      return (true, validTypes);
+    }
+
+    if (validateType(property) case (false, final validTypes)) {
+      throw CurrentTextControllerCurrentPropertyTypeException(
+        property,
+        'intController',
+        validTypes,
+      );
+    }
+
+    bind(
+      property: property,
+      lifecycleProvider: lifecycleProvider,
+      fromString:
+          fromString ?? (text) => (int.tryParse(text) ?? defaultValue) as T,
+      asString: asString,
+      defaultValue: defaultValue as T,
+    );
+  }
+
+  /// A convenience method for initializing the controller with properties based on [CurrentProperty<DateTime>]. This is equivalent to calling [bind] with fromString and asString configured for DateTime properties.
+  /// The [property] must be of type [CurrentProperty<DateTime>], [CurrentDateTimeProperty], or [CurrentNullableDateTimeProperty]. If it is not, this method will throw an exception.
+  ///
+  void bindDateTime({
+    required CurrentProperty<T> property,
+    required CurrentTextControllersLifecycleMixin lifecycleProvider,
+    required T Function(String text) fromString,
+    String? Function(T? propertyValue)? asString,
+    T? defaultValue,
+  }) {
+    (bool isValidType, List<Type> validTypes) validateType(
+        CurrentProperty property) {
+      final validTypes = [
+        CurrentProperty<DateTime>,
+        CurrentDateTimeProperty,
+        CurrentNullableDateTimeProperty
+      ];
+
+      // This is done in a verbose way, duplicating the list (unfortunately) to ensure type check safety,
+      // guarding against Darts reified generics. Simply checking via `validTypes.any((type) => property.runtimeType == type)`
+      // is not guaranteed to behave correctly due to possible type erasure.
+      if (property is CurrentProperty<DateTime> ||
+          property is CurrentDateTimeProperty ||
+          property is CurrentNullableDateTimeProperty) {
+        return (false, validTypes);
+      }
+      return (true, validTypes);
+    }
+
+    if (validateType(property) case (false, final validTypes)) {
+      throw CurrentTextControllerCurrentPropertyTypeException(
+        property,
+        'dateController',
+        validTypes,
+      );
+    }
+
+    bind(
+      property: property,
+      lifecycleProvider: lifecycleProvider,
+      fromString: fromString,
+      asString: asString ??
+          (propertyValue) =>
+              (propertyValue as DateTime?)?.toIso8601String() ??
+              'Unparsable Date',
+      defaultValue: defaultValue as T,
+    );
+  }
+
+  void _setText() {
+    final value =
+        asString?.call(property.value) ?? property.value?.toString() ?? '';
+
+    if (value != text) {
+      text = value;
+    }
+  }
+
+  T? _tryParseText(String text) {
+    try {
+      return fromString?.call(text) ?? defaultValue ?? text as T;
+    } catch (_) {
+      throw Exception(
+        'Failed to parse and set CurrentProperty "${property.propertyName ?? property.runtimeType}" with value "$text". Did you provide a fromString function or provide a defaultValue?',
+      );
+    }
+  }
+
+  @override
+  void dispose() {
+    _subscription.cancel();
+    super.dispose();
+  }
+}
+
+/// A mixin for managing the lifecycle of [CurrentTextController]s in a [CurrentState].
+/// This mixin ensures that the controllers are only initialized once.
+///
+/// Must implement [bindCurrentControllers]. This is where you should initialize your [CurrentTextController]s.
+mixin CurrentTextControllersLifecycleMixin<TWidget extends CurrentWidget,
+    TViewModel extends CurrentViewModel> on CurrentState<TWidget, TViewModel> {
+  bool _initializedControllers = false;
+
+  /// Whether the CurrentTextControllers have been initialized. This is used to ensure that the controllers are only initialized once.
+  bool get controllersInitialized => _initializedControllers;
+
+  void bindCurrentControllers();
+
+  @override
+  void didChangeDependencies() {
+    if (!controllersInitialized) {
+      bindCurrentControllers();
+      _initializedControllers = true;
+    }
+    super.didChangeDependencies();
+  }
+}

--- a/lib/src/current_text_controller.dart
+++ b/lib/src/current_text_controller.dart
@@ -318,9 +318,9 @@ final class CurrentTextController<T> extends TextEditingController {
       // This is done in a verbose way, duplicating the list (unfortunately) to ensure type check safety,
       // guarding against Darts reified generics. Simply checking via `validTypes.any((type) => property.runtimeType == type)`
       // is not guaranteed to behave correctly due to possible type erasure.
-      if (property is CurrentProperty<DateTime> ||
-          property is CurrentDateTimeProperty ||
-          property is CurrentNullableDateTimeProperty) {
+      if (property is! CurrentProperty<DateTime> &&
+          property is! CurrentDateTimeProperty &&
+          property is! CurrentNullableDateTimeProperty) {
         return (false, validTypes);
       }
       return (true, validTypes);

--- a/lib/src/current_text_controller.dart
+++ b/lib/src/current_text_controller.dart
@@ -400,6 +400,7 @@ final class CurrentTextController<T> extends TextEditingController {
     }
 
     _isSyncingText = true;
+
     try {
       value = TextEditingValue(
         text: nextText,
@@ -433,7 +434,7 @@ final class CurrentTextController<T> extends TextEditingController {
       return;
     }
 
-    boundProperty.set(parseResult.value);
+    boundProperty.value = parseResult.value;
   }
 
   ({bool shouldUpdate, T? value}) _tryParseText(String text) {
@@ -457,14 +458,12 @@ final class CurrentTextController<T> extends TextEditingController {
       return (shouldUpdate: false, value: null);
     }
 
-    final parser = _fromString;
-
-    if (parser == null) {
+    if (_fromString == null) {
       return (shouldUpdate: false, value: null);
     }
 
     try {
-      return (shouldUpdate: true, value: parser(text));
+      return (shouldUpdate: true, value: _fromString!(text));
     } catch (_) {
       return (shouldUpdate: false, value: null);
     }

--- a/lib/src/current_view_model.dart
+++ b/lib/src/current_view_model.dart
@@ -343,6 +343,8 @@ abstract class CurrentViewModel {
     }
 
     setMultiple(resetActions);
+    _busyTaskKeys.clear();
+    setNotBusy();
   }
 
   ///Closes the state and error streams and removes any listeners associated with those streams
@@ -366,9 +368,10 @@ class CurrentStateChanged<T> {
   final T? nextValue;
   final String? propertyName;
   final String? description;
+  final int? sourceHashCode;
 
   CurrentStateChanged(this.nextValue, this.previousValue,
-      {this.propertyName, this.description});
+      {this.propertyName, this.description, this.sourceHashCode});
 
   ///A factory method which creates a single [CurrentStateChanged] object with a description
   ///describing what value was added to the list

--- a/lib/src/current_view_model.dart
+++ b/lib/src/current_view_model.dart
@@ -89,7 +89,7 @@ abstract class CurrentViewModel {
   /// Note if you provide both a [filter] and [propertyName], the event handler will only be executed for events that satisfy both conditions.
   ///
   /// If an error occurs in the event handler, any event handlers registered with the [addOnErrorEventListener] function will be executed with an [ErrorEvent] containing the error.
-  StreamSubscription addStateChangedListener<T extends CurrentStateChanged>(
+  StreamSubscription<T> addStateChangedListener<T extends CurrentStateChanged>(
       void Function(T event) onStateChanged,
       {bool Function(T event)? filter,
       String? propertyName}) {
@@ -114,6 +114,22 @@ abstract class CurrentViewModel {
     _subscriptions.add(newSubscription);
 
     return newSubscription;
+  }
+
+  /// Adds an event handler for all [CurrentStateChanged] events without
+  /// requiring the caller to specify a concrete callback parameter type.
+  ///
+  /// This is a convenience wrapper around [addStateChangedListener] for cases
+  /// where the caller does not care about listening to a specific subclass.
+  StreamSubscription<CurrentStateChanged> addAnyStateChangedListener(
+      void Function(CurrentStateChanged event) onStateChanged,
+      {bool Function(CurrentStateChanged event)? filter,
+      String? propertyName}) {
+    return addStateChangedListener<CurrentStateChanged>(
+      onStateChanged,
+      filter: filter,
+      propertyName: propertyName,
+    );
   }
 
   ///Cancels the subscription. The subscriber will stop receiving events

--- a/lib/src/current_view_model.dart
+++ b/lib/src/current_view_model.dart
@@ -28,7 +28,7 @@ abstract class CurrentViewModel {
   /// This can be used to determine if any changes have been made to the view model since it was last reset or since the [originalValue] of the properties were last updated to their current values.
   bool get isDirty {
     for (final prop in currentProps) {
-      if (prop.value != prop.originalValue) return true;
+      if (prop.isDirty) return true;
     }
     return false;
   }

--- a/lib/src/current_view_model.dart
+++ b/lib/src/current_view_model.dart
@@ -81,6 +81,14 @@ abstract class CurrentViewModel {
     _assignedTo = widgetHash;
   }
 
+  /// Releases the current [CurrentState] assignment when it matches the
+  /// provided state identifier.
+  void releaseFrom(int widgetHash) {
+    if (_assignedTo == widgetHash) {
+      _assignedTo = null;
+    }
+  }
+
   /// Adds an event handler which gets executed each time an event of type [T] is added to the state stream.
   ///
   /// If the optional [filter] function is provided, the event handler will only be executed for events where the [filter] function returns true.
@@ -133,8 +141,8 @@ abstract class CurrentViewModel {
 
   ///Cancels the subscription. The subscriber will stop receiving events
   Future<void> cancelSubscription(StreamSubscription? subscription) async {
-    await subscription?.cancel();
     _subscriptions.remove(subscription);
+    await subscription?.cancel();
   }
 
   ///Adds an event handler which gets executed each time [notifyError] is called.

--- a/lib/src/current_view_model.dart
+++ b/lib/src/current_view_model.dart
@@ -214,7 +214,8 @@ abstract class CurrentViewModel {
       final nextValue = setter.values.first;
 
       changes.add(CurrentStateChanged(nextValue, previousValue,
-          propertyName: property.propertyName));
+          propertyName: property.propertyName,
+          sourceHashCode: property.sourceHashCode));
 
       property(nextValue, notifyChange: false);
     }

--- a/lib/src/current_view_model.dart
+++ b/lib/src/current_view_model.dart
@@ -413,97 +413,113 @@ class CurrentStateChanged<T> {
   ///A factory method which creates a single [CurrentStateChanged] object with a description
   ///describing what value was added to the list
   static CurrentStateChanged addedToList<V>(V newValue,
-          {String? propertyName}) =>
+          {String? propertyName, int? sourceHashCode}) =>
       CurrentStateChanged(newValue, null,
-          propertyName: propertyName, description: 'Added To List: $newValue');
+          propertyName: propertyName,
+          description: 'Added To List: $newValue',
+          sourceHashCode: sourceHashCode);
 
   ///A factory method which creates a single [CurrentStateChanged] object with a description
   ///describing all the values that were added to the list
   static CurrentStateChanged addedAllToList<V>(Iterable<V> newValues,
-          {String? propertyName}) =>
+          {String? propertyName, int? sourceHashCode}) =>
       CurrentStateChanged(newValues, null,
           propertyName: propertyName,
-          description: 'Added All To List: $newValues');
+          description: 'Added All To List: $newValues',
+          sourceHashCode: sourceHashCode);
 
   ///A factory method which creates a single [CurrentStateChanged] object with a description
   ///describing the value inserted into to the list at the specified index
   static CurrentStateChanged insertIntoList<V>(int index, V value,
-          {String? propertyName}) =>
+          {String? propertyName, int? sourceHashCode}) =>
       CurrentStateChanged(
         value,
         null,
         propertyName: propertyName,
         description: 'Inserted $value into List as index $index',
+        sourceHashCode: sourceHashCode,
       );
 
   ///A factory method which creates a single [CurrentStateChanged] object with a description
   ///describing all the values that were inserted into the list at the specified index
   static CurrentStateChanged insertAllIntoList<V>(int index, Iterable<V> values,
-          {String? propertyName}) =>
+          {String? propertyName, int? sourceHashCode}) =>
       CurrentStateChanged(values, null,
           propertyName: propertyName,
-          description: 'Inserted All $values into List as index $index');
+          description: 'Inserted All $values into List as index $index',
+          sourceHashCode: sourceHashCode);
 
   ///A factory method which creates a single [CurrentStateChanged] object with a description
   ///describing what value was removed from the list
   static CurrentStateChanged removedFromList<V>(V removedValue,
-          {String? propertyName}) =>
+          {String? propertyName, int? sourceHashCode}) =>
       CurrentStateChanged(null, removedValue,
           propertyName: propertyName,
-          description: 'Removed From List: $removedValue');
+          description: 'Removed From List: $removedValue',
+          sourceHashCode: sourceHashCode);
 
   ///A factory method which creates a single [CurrentStateChanged] object with a description
   ///stating that the entire list was cleared
   static CurrentStateChanged<Iterable<V>> clearedList<V>(Iterable<V> iterable,
-          {String? propertyName}) =>
+          {String? propertyName, int? sourceHashCode}) =>
       CurrentStateChanged(<V>[], iterable,
-          propertyName: propertyName, description: 'Iterable Cleared');
+          propertyName: propertyName,
+          description: 'Iterable Cleared',
+          sourceHashCode: sourceHashCode);
 
   ///A factory method which creates a single [CurrentStateChanged] object with a description
   ///describing what new map values were added to another map
   static CurrentStateChanged addedMapToMap<K, V>(Map<K, V> addedMap,
-      {String? propertyName}) {
+      {String? propertyName, int? sourceHashCode}) {
     return CurrentStateChanged(addedMap, null,
-        propertyName: propertyName, description: 'Added Map To Map: $addedMap');
+        propertyName: propertyName,
+        description: 'Added Map To Map: $addedMap',
+        sourceHashCode: sourceHashCode);
   }
 
   ///A factory method which creates a single [CurrentStateChanged] object with a description
   ///describing what key/value was added to the map
   static CurrentStateChanged addedToMap<K, V>(K key, V newValue,
-      {String? propertyName}) {
+      {String? propertyName, int? sourceHashCode}) {
     final newEntry = MapEntry(key, newValue);
     return CurrentStateChanged(newEntry, null,
-        propertyName: propertyName, description: 'Added To Map: $newEntry');
+        propertyName: propertyName,
+        description: 'Added To Map: $newEntry',
+        sourceHashCode: sourceHashCode);
   }
 
   ///A factory method which creates a single [CurrentStateChanged] object with a description
   ///describing what [MapEntry] objects were added to the map
   static CurrentStateChanged addedEntriesToMap<K, V>(
       Iterable<MapEntry<K, V>> entries,
-      {String? propertyName}) {
+      {String? propertyName,
+      int? sourceHashCode}) {
     return CurrentStateChanged(entries, null,
         propertyName: propertyName,
-        description: 'Added Entries To Map: $entries');
+        description: 'Added Entries To Map: $entries',
+        sourceHashCode: sourceHashCode);
   }
 
   ///A factory method which creates a single [CurrentStateChanged] object with a description
   ///describing what changes were made to a map entry, including for which key
   static CurrentStateChanged<V> updateMapEntry<K, V>(
       K key, V? originalValue, V? nextValue,
-      {String? propertyName}) {
+      {String? propertyName, int? sourceHashCode}) {
     return CurrentStateChanged<V>(nextValue, originalValue,
         propertyName: propertyName,
-        description: 'Update Map Value For Key: $key');
+        description: 'Update Map Value For Key: $key',
+        sourceHashCode: sourceHashCode);
   }
 
   ///A factory method which creates a single [CurrentStateChanged] object with a description
   ///describing what key/value was removed from the map
-  static CurrentStateChanged<V> removedFromMap<K, V>(K key, V removedValue,
-      {String? propertyName}) {
+  static CurrentStateChanged<V> removedFromMap<K, V>(K key, V? removedValue,
+      {String? propertyName, int? sourceHashCode}) {
     final removedEntry = MapEntry(key, removedValue);
     return CurrentStateChanged<V>(null, removedValue,
         propertyName: propertyName,
-        description: 'Removed From Map: $removedEntry');
+        description: 'Removed From Map: $removedEntry',
+        sourceHashCode: sourceHashCode);
   }
 
   @override

--- a/lib/src/current_view_model.dart
+++ b/lib/src/current_view_model.dart
@@ -249,13 +249,20 @@ abstract class CurrentViewModel {
       final previousValue = property.value;
       final nextValue = setter.values.first;
 
+      if (!property.hasValueChanged(nextValue, previousValue)) {
+        continue;
+      }
+
       changes.add(CurrentStateChanged(nextValue, previousValue,
           propertyName: property.propertyName,
           sourceHashCode: property.sourceHashCode));
 
       property(nextValue, notifyChange: false);
     }
-    notifyChanges(changes);
+
+    if (changes.isNotEmpty) {
+      notifyChanges(changes);
+    }
   }
 
   ///Inform the bound [CurrentState] that an error has occurred.

--- a/lib/src/current_view_model.dart
+++ b/lib/src/current_view_model.dart
@@ -116,8 +116,7 @@ abstract class CurrentViewModel {
     return newSubscription;
   }
 
-  /// Adds an event handler for all [CurrentStateChanged] events without
-  /// requiring the caller to specify a concrete callback parameter type.
+  /// Adds an event handler for all [CurrentStateChanged] events.
   ///
   /// This is a convenience wrapper around [addStateChangedListener] for cases
   /// where the caller does not care about listening to a specific subclass.
@@ -168,7 +167,7 @@ abstract class CurrentViewModel {
   ///});
   ///```
   ///
-  StreamSubscription addOnErrorEventListener<T extends ErrorEvent>(
+  StreamSubscription<T> addOnErrorEventListener<T extends ErrorEvent>(
       void Function(T event) onError,
       {void Function(Object error, StackTrace stackTrace)? onInternalError}) {
     final newSubscription = _errorController.stream
@@ -178,6 +177,19 @@ abstract class CurrentViewModel {
 
     _subscriptions.add(newSubscription);
     return newSubscription;
+  }
+
+  /// Adds an event handler for all [ErrorEvent] values
+  ///
+  /// This is a convenience wrapper around [addOnErrorEventListener] for cases
+  /// where the caller wants to observe any error event.
+  StreamSubscription<ErrorEvent> addAnyErrorEventListener(
+      void Function(ErrorEvent event) onError,
+      {void Function(Object error, StackTrace stackTrace)? onInternalError}) {
+    return addOnErrorEventListener<ErrorEvent>(
+      onError,
+      onInternalError: onInternalError,
+    );
   }
 
   ///Inform the bound [CurrentState] that the state of the UI needs to be updated.

--- a/lib/src/current_view_model.dart
+++ b/lib/src/current_view_model.dart
@@ -366,12 +366,20 @@ abstract class CurrentViewModel {
   ///to their original value.
   ///
   void resetAll() {
-    final resetActions = <Map<CurrentProperty, dynamic>>[];
+    final resetEvents = <CurrentStateChanged>[];
     for (final prop in currentProps) {
-      resetActions.add({prop: prop.originalValue});
+      final previousValue = prop.value;
+      prop.reset(notifyChange: false);
+
+      resetEvents.add(CurrentStateChanged(
+        prop.value,
+        previousValue,
+        propertyName: prop.propertyName,
+        sourceHashCode: prop.sourceHashCode,
+      ));
     }
 
-    setMultiple(resetActions);
+    notifyChanges(resetEvents);
     _busyTaskKeys.clear();
     setNotBusy();
   }

--- a/lib/src/current_widget.dart
+++ b/lib/src/current_widget.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
@@ -7,6 +9,9 @@ import 'current_view_model.dart';
 ///
 ///Requires a class that extends [CurrentViewModel] to be passed to the [viewModel] argument. The
 ///[CurrentViewModel] is responsible for notifying this widget when the UI needs to be updated.
+///By default, [CurrentWidget] also owns the lifecycle of the provided [viewModel] and disposes it
+///when the accompanying [CurrentState] is disposed. Set [disposeViewModel] to `false` when using
+///an externally managed or shared [CurrentViewModel] instance.
 ///
 ///### Usage
 ///
@@ -24,10 +29,21 @@ abstract class CurrentWidget<T extends CurrentViewModel>
     extends StatefulWidget {
   final T viewModel;
   final bool debugPrintStateChanges;
+
+  /// Whether this widget owns the lifecycle of the provided [viewModel].
+  ///
+  /// When true, disposing the [CurrentState] will also dispose the
+  /// [CurrentViewModel].
+  ///
+  /// Set this to false when the [viewModel] is managed externally and should
+  /// survive widget disposal so it can be rebound later.
+  final bool disposeViewModel;
+
   const CurrentWidget({
     super.key,
     required this.viewModel,
     this.debugPrintStateChanges = false,
+    this.disposeViewModel = true,
   });
 
   ///Create an instance of [CurrentState] for this widget.
@@ -88,8 +104,11 @@ abstract class CurrentWidget<T extends CurrentViewModel>
 ///}
 ///```
 ///**IMPORTANT**
-///If you expect the parent widget of [T] to cause [T] to rebuild, you should use the Flutter [AutomaticKeepAliveClientMixin]
-///on the [CurrentState] implementation to prevent the state from being disposed and recreated, which will cause the view model to be reassigned and throw a [CurrentViewModelAlreadyAssignedException].
+///If you expect the parent widget of [T] to cause [T] to rebuild while reusing the same
+///[CurrentViewModel] instance, you should either use the Flutter [AutomaticKeepAliveClientMixin]
+///on the [CurrentState] implementation or set [CurrentWidget.disposeViewModel] to `false` and manage
+///the view model lifecycle yourself. Otherwise, the default owned lifecycle will dispose the view
+///model with the state.
 ///
 ///For example:
 ///```dart
@@ -110,6 +129,7 @@ abstract class CurrentWidget<T extends CurrentViewModel>
 abstract class CurrentState<T extends CurrentWidget, E extends CurrentViewModel>
     extends State<T> {
   final E viewModel;
+  late final StreamSubscription<CurrentStateChanged> _stateChangedSubscription;
 
   ///Exposes the [viewModel] busy status. Used to determine if the [viewModel] is busy running
   ///a long running task
@@ -117,10 +137,15 @@ abstract class CurrentState<T extends CurrentWidget, E extends CurrentViewModel>
 
   CurrentState(this.viewModel) {
     WidgetsBinding.instance.addPostFrameCallback(
-      (_) => viewModel.assignTo(hashCode),
+      (_) {
+        if (mounted) {
+          viewModel.assignTo(hashCode);
+        }
+      },
     );
 
-    viewModel.addStateChangedListener<CurrentStateChanged>((event) {
+    _stateChangedSubscription =
+        viewModel.addStateChangedListener<CurrentStateChanged>((event) {
       if (widget.debugPrintStateChanges && kDebugMode) {
         // ignore: avoid_print
         print(event);
@@ -143,7 +168,12 @@ abstract class CurrentState<T extends CurrentWidget, E extends CurrentViewModel>
   @override
   @mustCallSuper
   void dispose() {
-    viewModel.dispose();
+    if (widget.disposeViewModel) {
+      viewModel.dispose();
+    } else {
+      viewModel.cancelSubscription(_stateChangedSubscription);
+      viewModel.releaseFrom(hashCode);
+    }
     super.dispose();
   }
 }

--- a/test/current_property_tests/current_property_test.dart
+++ b/test/current_property_tests/current_property_test.dart
@@ -106,18 +106,20 @@ void main() {
       expect(ageOne.equals(ageTwo), isFalse);
     });
 
-    test('equals - other is CurrentProperty with same value - are equal', () {
+    test('equals - other is numeric value with same value - are equal', () {
       final ageOne = CurrentProperty<int>(10);
       const double ageTwo = 10.0;
 
       expect(ageOne.equals(ageTwo), isTrue);
     });
 
-    test('equality - other is CurrentProperty with same value - are equal', () {
+    test(
+        'equality - other is distinct CurrentProperty with same value - are not equal',
+        () {
       final ageOne = CurrentProperty<int>(10);
       final ageTwo = CurrentProperty<int>(10);
 
-      expect(ageOne == ageTwo, isTrue);
+      expect(ageOne == ageTwo, isFalse);
     });
 
     test(
@@ -129,14 +131,18 @@ void main() {
       expect(ageOne == ageTwo, isFalse);
     });
 
-    test(
-        'equality - other is same as CurrentProperty generic type argument with same value - are equal',
-        () {
+    test('equality - same instance - are equal', () {
+      final age = CurrentProperty<int>(10);
+
+      expect(age == age, isTrue);
+    });
+
+    test('equality - other is raw value with same value - are not equal', () {
       final ageOne = CurrentProperty<int>(10);
       const int ageTwo = 10;
 
       // ignore: unrelated_type_equality_checks
-      expect(ageOne == ageTwo, isTrue);
+      expect(ageOne == ageTwo, isFalse);
     });
 
     test(
@@ -157,6 +163,29 @@ void main() {
 
       // ignore: unrelated_type_equality_checks
       expect(ageOne == name, isFalse);
+    });
+
+    test('hashCode - value changes - hashCode remains stable', () {
+      final age = CurrentProperty<int>(10, isPrimitiveType: true);
+      final initialHashCode = age.hashCode;
+
+      age.set(20, notifyChange: false);
+
+      expect(age.hashCode, equals(initialHashCode));
+    });
+
+    test('equality - distinct properties can coexist as map keys', () {
+      final ageOne = CurrentProperty<int>(10);
+      final ageTwo = CurrentProperty<int>(10);
+
+      final values = {
+        ageOne: 'first',
+        ageTwo: 'second',
+      };
+
+      expect(values.length, equals(2));
+      expect(values[ageOne], equals('first'));
+      expect(values[ageTwo], equals('second'));
     });
 
     test('isNull - value is null - returns true', () {

--- a/test/current_property_tests/double_property_test.dart
+++ b/test/current_property_tests/double_property_test.dart
@@ -1,4 +1,5 @@
 import 'package:current/current.dart';
+import 'package:current/src/current_exceptions.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -264,6 +265,122 @@ void main() {
       final result = number.mod(3.5);
 
       expect(result, equals(expected));
+    });
+  });
+
+  group('CurrentNullableDoubleProperty Tests', () {
+    late NullableDoubleViewModel viewModel;
+
+    setUp(() {
+      viewModel = NullableDoubleViewModel();
+    });
+
+    test('isNegative - value is null - returns false', () {
+      expect(viewModel.percentage.isNegative, isFalse);
+    });
+
+    test('isNegative - number is negative - returns true', () {
+      viewModel.percentage(-3.2);
+
+      expect(viewModel.percentage.isNegative, isTrue);
+    });
+
+    test('toInt - value is null - returns null', () {
+      expect(viewModel.percentage.toInt(), isNull);
+    });
+
+    test('toInt - value is set - returns truncated int', () {
+      viewModel.percentage(10.75);
+
+      expect(viewModel.percentage.toInt(), equals(10));
+    });
+
+    test('round - value is null - returns null', () {
+      expect(viewModel.percentage.round(), isNull);
+    });
+
+    test('round - value is set - returns rounded int', () {
+      viewModel.percentage(10.5);
+
+      expect(viewModel.percentage.round(), equals(11));
+    });
+
+    test('roundToDouble - value is null - returns null', () {
+      expect(viewModel.percentage.roundToDouble(), isNull);
+    });
+
+    test('roundToDouble - value is set - returns rounded double', () {
+      viewModel.percentage(10.23);
+
+      expect(viewModel.percentage.roundToDouble(), equals(10.0));
+    });
+
+    test('add - value is null - throws CurrentPropertyNullValueException', () {
+      expect(
+        () => viewModel.percentage.add(1),
+        throwsA(isA<CurrentPropertyNullValueException>()),
+      );
+    });
+
+    test('add - value is set - returns correct double value', () {
+      viewModel.percentage(1.0);
+
+      expect(viewModel.percentage.add(1.5), equals(2.5));
+    });
+
+    test('subtract - value is null - throws CurrentPropertyNullValueException',
+        () {
+      expect(
+        () => viewModel.percentage.subtract(1),
+        throwsA(isA<CurrentPropertyNullValueException>()),
+      );
+    });
+
+    test('subtract - value is set - returns correct double value', () {
+      viewModel.percentage(4.0);
+
+      expect(viewModel.percentage.subtract(1.5), equals(2.5));
+    });
+
+    test('multiply - value is null - throws CurrentPropertyNullValueException',
+        () {
+      expect(
+        () => viewModel.percentage.multiply(2),
+        throwsA(isA<CurrentPropertyNullValueException>()),
+      );
+    });
+
+    test('multiply - value is set - returns correct double value', () {
+      viewModel.percentage(2.0);
+
+      expect(viewModel.percentage.multiply(2.7), equals(5.4));
+    });
+
+    test('divide - value is null - throws CurrentPropertyNullValueException',
+        () {
+      expect(
+        () => viewModel.percentage.divide(2),
+        throwsA(isA<CurrentPropertyNullValueException>()),
+      );
+    });
+
+    test('divide - value is set - returns correct double value', () {
+      viewModel.percentage(8.0);
+
+      expect(viewModel.percentage.divide(2), equals(4.0));
+    });
+
+    test('mod - value is null - throws CurrentPropertyNullValueException', () {
+      expect(
+        () => viewModel.percentage.mod(3),
+        throwsA(isA<CurrentPropertyNullValueException>()),
+      );
+    });
+
+    test('mod - value is set - returns correct double value', () {
+      viewModel.percentage(5.0);
+
+      expect(viewModel.percentage.mod(3.5), equals(1.5));
     });
   });
 }

--- a/test/current_property_tests/int_property_test.dart
+++ b/test/current_property_tests/int_property_test.dart
@@ -1,4 +1,5 @@
 import 'package:current/current.dart';
+import 'package:current/src/current_exceptions.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -218,10 +219,34 @@ void main() {
       expect(result, equals(expected));
     });
 
+    test('add - explicit num generic with int value - returns num value', () {
+      const num expected = 2;
+      final number = CurrentIntProperty(1);
+      final result = number.add<num>(1);
+
+      expect(result, equals(expected));
+    });
+
+    test('addNumber - int value - returns numeric value', () {
+      const num expected = 2;
+      final number = CurrentIntProperty(1);
+      final result = number.addNumber(1);
+
+      expect(result, equals(expected));
+    });
+
     test('add - other is double - returns correct double value', () {
       const expected = 2.5;
       final number = CurrentIntProperty(1);
       final result = number.add(1.5);
+
+      expect(result, equals(expected));
+    });
+
+    test('addNumber - double value - returns numeric value', () {
+      const num expected = 2.5;
+      final number = CurrentIntProperty(1);
+      final result = number.addNumber(1.5);
 
       expect(result, equals(expected));
     });
@@ -234,10 +259,26 @@ void main() {
       expect(result, equals(expected));
     });
 
+    test('subtractNumber - int value - returns numeric value', () {
+      const num expected = 2;
+      final number = CurrentIntProperty(3);
+      final result = number.subtractNumber(1);
+
+      expect(result, equals(expected));
+    });
+
     test('subtract - other is double - returns correct double value', () {
       const expected = 2.5;
       final number = CurrentIntProperty(4);
       final result = number.subtract(1.5);
+
+      expect(result, equals(expected));
+    });
+
+    test('subtractNumber - double value - returns numeric value', () {
+      const num expected = 2.5;
+      final number = CurrentIntProperty(4);
+      final result = number.subtractNumber(1.5);
 
       expect(result, equals(expected));
     });
@@ -250,10 +291,26 @@ void main() {
       expect(result, equals(expected));
     });
 
+    test('multiplyNumber - int value - returns numeric value', () {
+      const num expected = 4;
+      final number = CurrentIntProperty(2);
+      final result = number.multiplyNumber(2);
+
+      expect(result, equals(expected));
+    });
+
     test('multiply - other is double - returns correct double value', () {
       const expected = 5.4;
       final number = CurrentIntProperty(2);
       final result = number.multiply(2.7);
+
+      expect(result, equals(expected));
+    });
+
+    test('multiplyNumber - double value - returns numeric value', () {
+      const num expected = 5.4;
+      final number = CurrentIntProperty(2);
+      final result = number.multiplyNumber(2.7);
 
       expect(result, equals(expected));
     });
@@ -274,12 +331,100 @@ void main() {
       expect(result, equals(expected));
     });
 
+    test('modNumber - int value - returns numeric value', () {
+      const num expected = 2;
+      final number = CurrentIntProperty(5);
+      final result = number.modNumber(3);
+
+      expect(result, equals(expected));
+    });
+
     test('mod - other is double - returns correct double value', () {
       const expected = 1.5;
       final number = CurrentIntProperty(5);
       final result = number.mod(3.5);
 
       expect(result, equals(expected));
+    });
+
+    test('modNumber - double value - returns numeric value', () {
+      const num expected = 1.5;
+      final number = CurrentIntProperty(5);
+      final result = number.modNumber(3.5);
+
+      expect(result, equals(expected));
+    });
+
+    test(
+        'nullable addNumber - null value - throws CurrentPropertyNullValueException',
+        () {
+      final number = CurrentNullableIntProperty();
+
+      expect(
+        () => number.addNumber(1),
+        throwsA(isA<CurrentPropertyNullValueException>()),
+      );
+    });
+
+    test('nullable addNumber - double value - returns numeric value', () {
+      final number = CurrentNullableIntProperty(value: 1);
+      final result = number.addNumber(1.5);
+
+      expect(result, equals(2.5));
+    });
+
+    test(
+        'nullable subtractNumber - null value - throws CurrentPropertyNullValueException',
+        () {
+      final number = CurrentNullableIntProperty();
+
+      expect(
+        () => number.subtractNumber(1),
+        throwsA(isA<CurrentPropertyNullValueException>()),
+      );
+    });
+
+    test('nullable subtractNumber - double value - returns numeric value', () {
+      final number = CurrentNullableIntProperty(value: 4);
+      final result = number.subtractNumber(1.5);
+
+      expect(result, equals(2.5));
+    });
+
+    test(
+        'nullable multiplyNumber - null value - throws CurrentPropertyNullValueException',
+        () {
+      final number = CurrentNullableIntProperty();
+
+      expect(
+        () => number.multiplyNumber(2),
+        throwsA(isA<CurrentPropertyNullValueException>()),
+      );
+    });
+
+    test('nullable multiplyNumber - double value - returns numeric value', () {
+      final number = CurrentNullableIntProperty(value: 2);
+      final result = number.multiplyNumber(2.7);
+
+      expect(result, equals(5.4));
+    });
+
+    test(
+        'nullable modNumber - null value - throws CurrentPropertyNullValueException',
+        () {
+      final number = CurrentNullableIntProperty();
+
+      expect(
+        () => number.modNumber(3),
+        throwsA(isA<CurrentPropertyNullValueException>()),
+      );
+    });
+
+    test('nullable modNumber - double value - returns numeric value', () {
+      final number = CurrentNullableIntProperty(value: 5);
+      final result = number.modNumber(3.5);
+
+      expect(result, equals(1.5));
     });
   });
 }

--- a/test/current_property_tests/list_property_test.dart
+++ b/test/current_property_tests/list_property_test.dart
@@ -142,7 +142,7 @@ void main() {
       expect(result, isTrue);
     });
 
-    test('contains - does not contain item - returns true', () {
+    test('contains - does not contain item - returns false', () {
       String earth = 'Earth';
       String venus = 'Venus';
 
@@ -266,8 +266,7 @@ void main() {
       await subscription.cancel();
     });
 
-    test('insertAllAtEnd - emits original index where item was inserted',
-        () async {
+    test('insertAllAtEnd - emits original insertion index', () async {
       CurrentStateChanged? receivedEvent;
 
       final subscription = viewModel
@@ -333,7 +332,7 @@ void main() {
       expect(data.contains(listItem), isTrue);
     });
 
-    test('ellementAt - list is not empty - returns correct object', () {
+    test('elementAt - list is not empty - returns correct object', () {
       const String expected = 'Frank';
       const int index = 1;
       final list = CurrentListProperty<String>(['Bob', expected]);

--- a/test/current_property_tests/list_property_test.dart
+++ b/test/current_property_tests/list_property_test.dart
@@ -3,7 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 class ListViewModel extends CurrentViewModel {
-  final planets = CurrentListProperty<String>.empty();
+  final planets = CurrentListProperty<String>.empty(propertyName: 'planets');
 
   @override
   Iterable<CurrentProperty> get currentProps => [planets];
@@ -224,6 +224,85 @@ void main() {
       list.add('Frank', notifyChanges: false);
 
       expect(list.isDirty, isTrue);
+    });
+
+    test('add - emits event with property metadata', () async {
+      CurrentStateChanged? receivedEvent;
+
+      final subscription = viewModel
+          .addAnyStateChangedListener((event) => receivedEvent = event);
+
+      viewModel.planets.add('Earth');
+      await Future<void>.microtask(() {});
+
+      expect(receivedEvent, isNotNull);
+      expect(receivedEvent?.nextValue, equals('Earth'));
+      expect(receivedEvent?.previousValue, isNull);
+      expect(receivedEvent?.propertyName, equals('planets'));
+      expect(receivedEvent?.sourceHashCode,
+          equals(viewModel.planets.sourceHashCode));
+
+      await subscription.cancel();
+    });
+
+    test('insert - emits inserted value instead of entire list', () async {
+      CurrentStateChanged? receivedEvent;
+
+      final subscription = viewModel
+          .addAnyStateChangedListener((event) => receivedEvent = event);
+
+      viewModel.planets.addAll(['Mercury', 'Venus'], notifyChanges: false);
+      viewModel.planets.insert(1, 'Earth');
+      await Future<void>.microtask(() {});
+
+      expect(receivedEvent, isNotNull);
+      expect(receivedEvent?.nextValue, equals('Earth'));
+      expect(
+        receivedEvent?.description,
+        equals('Inserted Earth into List as index 1'),
+      );
+      expect(receivedEvent?.propertyName, equals('planets'));
+
+      await subscription.cancel();
+    });
+
+    test('insertAllAtEnd - emits original index where item was inserted',
+        () async {
+      CurrentStateChanged? receivedEvent;
+
+      final subscription = viewModel
+          .addAnyStateChangedListener((event) => receivedEvent = event);
+
+      viewModel.planets.addAll(['Mercury', 'Venus'], notifyChanges: false);
+      viewModel.planets.insertAllAtEnd(['Earth', 'Mars']);
+      await Future<void>.microtask(() {});
+
+      expect(receivedEvent, isNotNull);
+      expect(receivedEvent?.nextValue, equals(['Earth', 'Mars']));
+      expect(
+        receivedEvent?.description,
+        equals('Inserted All [Earth, Mars] into List as index 2'),
+      );
+
+      await subscription.cancel();
+    });
+
+    test('clear - emits a stable snapshot of previous items', () async {
+      CurrentStateChanged? receivedEvent;
+
+      final subscription = viewModel
+          .addAnyStateChangedListener((event) => receivedEvent = event);
+
+      viewModel.planets.addAll(['Earth', 'Mars'], notifyChanges: false);
+      viewModel.planets.clear();
+      await Future<void>.microtask(() {});
+
+      expect(receivedEvent, isNotNull);
+      expect(receivedEvent?.previousValue, equals(['Earth', 'Mars']));
+      expect(receivedEvent?.nextValue, equals(<String>[]));
+      expect(receivedEvent?.propertyName, equals('planets'));
+
+      await subscription.cancel();
     });
 
     test(

--- a/test/current_property_tests/list_property_test.dart
+++ b/test/current_property_tests/list_property_test.dart
@@ -211,6 +211,21 @@ void main() {
       expect(list.isNotEmpty, isTrue);
     });
 
+    test('isDirty - list is unchanged from original value - returns false', () {
+      final list = CurrentListProperty<String>(['Bob']);
+
+      expect(list.isDirty, isFalse);
+    });
+
+    test('isDirty - list changes from original value - returns true', () {
+      final list = CurrentListProperty<String>(['Bob']);
+      list.setViewModel(viewModel);
+
+      list.add('Frank', notifyChanges: false);
+
+      expect(list.isDirty, isTrue);
+    });
+
     test(
         'reset - starting list is empty - add item - should be empty after reset',
         () {

--- a/test/current_property_tests/map_property_test.dart
+++ b/test/current_property_tests/map_property_test.dart
@@ -3,7 +3,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/material.dart';
 
 class MapViewModel extends CurrentViewModel {
-  final data = CurrentMapProperty<String, String>.empty();
+  final data = CurrentMapProperty<String, String>.empty(propertyName: 'data');
 
   @override
   Iterable<CurrentProperty> get currentProps => [data];
@@ -377,6 +377,47 @@ void main() {
       final data = CurrentMapProperty<String, String>({'name': 'Bob'});
 
       expect(data.isDirty, isFalse);
+    });
+
+    test('add - emits event with property metadata', () async {
+      CurrentStateChanged? receivedEvent;
+
+      final subscription = viewModel
+          .addAnyStateChangedListener((event) => receivedEvent = event);
+
+      viewModel.data.add('name', 'Bob');
+      await Future<void>.microtask(() {});
+
+      expect(receivedEvent, isNotNull);
+      final nextValue = receivedEvent?.nextValue as MapEntry<String, String>?;
+      expect(nextValue?.key, equals('name'));
+      expect(nextValue?.value, equals('Bob'));
+      expect(receivedEvent?.previousValue, isNull);
+      expect(receivedEvent?.propertyName, equals('data'));
+      expect(
+          receivedEvent?.sourceHashCode, equals(viewModel.data.sourceHashCode));
+
+      await subscription.cancel();
+    });
+
+    test('clear - emits a concrete snapshot of previous items', () async {
+      CurrentStateChanged? receivedEvent;
+
+      final subscription = viewModel
+          .addAnyStateChangedListener((event) => receivedEvent = event);
+
+      viewModel.data
+          .addAll({'name': 'Bob', 'planet': 'Earth'}, notifyChanges: false);
+      viewModel.data.clear();
+      await Future<void>.microtask(() {});
+
+      expect(receivedEvent, isNotNull);
+      expect(receivedEvent?.previousValue,
+          equals({'name': 'Bob', 'planet': 'Earth'}));
+      expect(receivedEvent?.nextValue, equals(<String, String>{}));
+      expect(receivedEvent?.propertyName, equals('data'));
+
+      await subscription.cancel();
     });
 
     test('isDirty - map changes from original value - returns true', () {

--- a/test/current_property_tests/map_property_test.dart
+++ b/test/current_property_tests/map_property_test.dart
@@ -372,6 +372,22 @@ void main() {
 
       expect(result, isNull);
     });
+
+    test('isDirty - map is unchanged from original value - returns false', () {
+      final data = CurrentMapProperty<String, String>({'name': 'Bob'});
+
+      expect(data.isDirty, isFalse);
+    });
+
+    test('isDirty - map changes from original value - returns true', () {
+      final data = CurrentMapProperty<String, String>({'name': 'Bob'});
+      data.setViewModel(viewModel);
+
+      data.add('lastName', 'Smith', notifyChanges: false);
+
+      expect(data.isDirty, isTrue);
+    });
+
     test(
         'reset - starting map is empty - add item - should be empty after reset',
         () {

--- a/test/current_property_tests/map_property_test.dart
+++ b/test/current_property_tests/map_property_test.dart
@@ -361,7 +361,7 @@ void main() {
       expect(result, equals(value));
     });
 
-    test('[] operator - has no matching key - returns value', () {
+    test('[] operator - has no matching key - returns null', () {
       const String key = 'name';
       const String value = 'Bob';
       const String missingKey = 'lastName';

--- a/test/current_text_controller_test.dart
+++ b/test/current_text_controller_test.dart
@@ -198,6 +198,33 @@ void main() {
       expect(ageController.text, '5');
     });
 
+    testWidgets(
+        'clearing a non-nullable property without a default re-syncs and selects the field',
+        (tester) async {
+      await tester.pumpWidget(
+        _ControllerTestWidget(
+          viewModel: viewModel,
+          nameController: nameController,
+          ageController: ageController,
+          nullableAgeController: nullableAgeController,
+        ),
+      );
+
+      await tester.enterText(find.byKey(const Key('age-field')), '3');
+      await tester.pump();
+
+      expect(viewModel.age.value, 3);
+      expect(ageController.text, '3');
+
+      await tester.enterText(find.byKey(const Key('age-field')), '');
+      await tester.pump();
+
+      expect(viewModel.age.value, 3);
+      expect(ageController.text, '3');
+      expect(ageController.selection.baseOffset, 0);
+      expect(ageController.selection.extentOffset, 1);
+    });
+
     testWidgets('empty text clears nullable integer properties',
         (tester) async {
       await tester.pumpWidget(

--- a/test/current_text_controller_test.dart
+++ b/test/current_text_controller_test.dart
@@ -331,8 +331,7 @@ void main() {
       expect(ageController.text, '10');
     });
 
-    testWidgets('property reset updates bound controller text',
-        (tester) async {
+    testWidgets('property reset updates bound controller text', (tester) async {
       await tester.pumpWidget(
         _ControllerTestWidget(
           viewModel: viewModel,

--- a/test/current_text_controller_test.dart
+++ b/test/current_text_controller_test.dart
@@ -1,0 +1,255 @@
+import 'package:current/current.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+class _ControllerTestViewModel extends CurrentViewModel {
+  final name = CurrentStringProperty('Alice', propertyName: 'name');
+  final age = CurrentIntProperty(10, propertyName: 'age');
+  final alternateAge = CurrentIntProperty(20, propertyName: 'alternateAge');
+  final nullableAge =
+      CurrentNullableIntProperty(value: 7, propertyName: 'nullableAge');
+
+  @override
+  Iterable<CurrentProperty> get currentProps => [
+        name,
+        age,
+        alternateAge,
+        nullableAge,
+      ];
+}
+
+class _ControllerTestWidget extends CurrentWidget<_ControllerTestViewModel> {
+  final CurrentTextController<String> nameController;
+  final CurrentTextController<int> ageController;
+  final CurrentTextController<int?> nullableAgeController;
+  final bool bindAlternateAge;
+  final int? ageDefaultValue;
+
+  const _ControllerTestWidget({
+    required super.viewModel,
+    required this.nameController,
+    required this.ageController,
+    required this.nullableAgeController,
+    this.bindAlternateAge = false,
+    this.ageDefaultValue,
+  });
+
+  @override
+  CurrentState<CurrentWidget<CurrentViewModel>, _ControllerTestViewModel>
+      createCurrent() => _ControllerTestState(viewModel);
+}
+
+class _ControllerTestState
+    extends CurrentState<_ControllerTestWidget, _ControllerTestViewModel>
+    with CurrentTextControllersLifecycleMixin {
+  _ControllerTestState(super.viewModel);
+
+  @override
+  void bindCurrentControllers() {
+    widget.nameController.bindString(
+      property: viewModel.name,
+      lifecycleProvider: this,
+    );
+
+    widget.ageController.bindInt(
+      property:
+          widget.bindAlternateAge ? viewModel.alternateAge : viewModel.age,
+      lifecycleProvider: this,
+      defaultValue: widget.ageDefaultValue,
+    );
+
+    widget.nullableAgeController.bindInt(
+      property: viewModel.nullableAge,
+      lifecycleProvider: this,
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      home: Scaffold(
+        body: Column(
+          children: [
+            TextField(
+              key: const Key('name-field'),
+              controller: widget.nameController,
+            ),
+            TextField(
+              key: const Key('age-field'),
+              controller: widget.ageController,
+            ),
+            TextField(
+              key: const Key('nullable-age-field'),
+              controller: widget.nullableAgeController,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+void main() {
+  group('CurrentTextController', () {
+    late _ControllerTestViewModel viewModel;
+    late CurrentTextController<String> nameController;
+    late CurrentTextController<int> ageController;
+    late CurrentTextController<int?> nullableAgeController;
+
+    setUp(() {
+      viewModel = _ControllerTestViewModel();
+      nameController = CurrentTextController.string();
+      ageController = CurrentTextController.integer();
+      nullableAgeController = CurrentTextController.nullableInteger();
+    });
+
+    tearDown(() {
+      nameController.dispose();
+      ageController.dispose();
+      nullableAgeController.dispose();
+    });
+
+    test('unbound controller works just like a normal TextEditingController',
+        () {
+      final controller = CurrentTextController.integer();
+
+      controller.text = '123';
+
+      expect(controller.text, '123');
+
+      controller.dispose();
+    });
+
+    testWidgets('valid text updates the bound property', (tester) async {
+      await tester.pumpWidget(
+        _ControllerTestWidget(
+          viewModel: viewModel,
+          nameController: nameController,
+          ageController: ageController,
+          nullableAgeController: nullableAgeController,
+        ),
+      );
+
+      await tester.enterText(find.byKey(const Key('age-field')), '42');
+      await tester.pump();
+
+      expect(viewModel.age.value, 42);
+      expect(ageController.text, '42');
+    });
+
+    testWidgets('external property changes update the bound text',
+        (tester) async {
+      await tester.pumpWidget(
+        _ControllerTestWidget(
+          viewModel: viewModel,
+          nameController: nameController,
+          ageController: ageController,
+          nullableAgeController: nullableAgeController,
+        ),
+      );
+
+      viewModel.age(11);
+      await tester.pump();
+
+      expect(ageController.text, '11');
+    });
+
+    testWidgets(
+        'invalid text stays visible and unrelated property events do not nuke it',
+        (tester) async {
+      await tester.pumpWidget(
+        _ControllerTestWidget(
+          viewModel: viewModel,
+          nameController: nameController,
+          ageController: ageController,
+          nullableAgeController: nullableAgeController,
+        ),
+      );
+
+      await tester.enterText(find.byKey(const Key('age-field')), 'abc');
+      await tester.pump();
+
+      expect(viewModel.age.value, 10);
+      expect(ageController.text, 'abc');
+
+      viewModel.alternateAge(10);
+      await tester.pump();
+
+      expect(viewModel.age.value, 10);
+      expect(ageController.text, 'abc');
+    });
+
+    testWidgets('empty text applies the explicit default for non-nullable ints',
+        (tester) async {
+      await tester.pumpWidget(
+        _ControllerTestWidget(
+          viewModel: viewModel,
+          nameController: nameController,
+          ageController: ageController,
+          nullableAgeController: nullableAgeController,
+          ageDefaultValue: 5,
+        ),
+      );
+
+      await tester.enterText(find.byKey(const Key('age-field')), '');
+      await tester.pump();
+
+      expect(viewModel.age.value, 5);
+      expect(ageController.text, '5');
+    });
+
+    testWidgets('empty text clears nullable integer properties',
+        (tester) async {
+      await tester.pumpWidget(
+        _ControllerTestWidget(
+          viewModel: viewModel,
+          nameController: nameController,
+          ageController: ageController,
+          nullableAgeController: nullableAgeController,
+        ),
+      );
+
+      await tester.enterText(find.byKey(const Key('nullable-age-field')), '');
+      await tester.pump();
+
+      expect(viewModel.nullableAge.value, isNull);
+      expect(nullableAgeController.text, '');
+    });
+
+    testWidgets(
+        'controllers rebind when bindCurrentControllers targets a new property',
+        (tester) async {
+      await tester.pumpWidget(
+        _ControllerTestWidget(
+          viewModel: viewModel,
+          nameController: nameController,
+          ageController: ageController,
+          nullableAgeController: nullableAgeController,
+        ),
+      );
+
+      expect(ageController.text, '10');
+
+      await tester.pumpWidget(
+        _ControllerTestWidget(
+          viewModel: viewModel,
+          nameController: nameController,
+          ageController: ageController,
+          nullableAgeController: nullableAgeController,
+          bindAlternateAge: true,
+        ),
+      );
+      await tester.pump();
+
+      expect(ageController.text, '20');
+
+      viewModel.age(99);
+      await tester.pump();
+      expect(ageController.text, '20');
+
+      viewModel.alternateAge(21);
+      await tester.pump();
+      expect(ageController.text, '21');
+    });
+  });
+}

--- a/test/current_text_controller_test.dart
+++ b/test/current_text_controller_test.dart
@@ -18,6 +18,64 @@ class _ControllerTestViewModel extends CurrentViewModel {
       ];
 }
 
+class _TestCustomObject {
+  final int id;
+  final String label;
+
+  const _TestCustomObject({required this.id, required this.label});
+
+  static _TestCustomObject parse(String text) {
+    final parts = text.split(':');
+
+    if (parts.length != 2) {
+      throw const FormatException('Expected format: <id>:<label>');
+    }
+
+    return _TestCustomObject(id: int.parse(parts[0]), label: parts[1]);
+  }
+
+  String serialize() => '$id:$label';
+
+  @override
+  bool operator ==(Object other) {
+    return other is _TestCustomObject && other.id == id && other.label == label;
+  }
+
+  @override
+  int get hashCode => Object.hash(id, label);
+}
+
+class _AdditionalTypesViewModel extends CurrentViewModel {
+  final title = CurrentStringProperty('Alpha', propertyName: 'title');
+
+  final nullableTitle = CurrentNullableStringProperty(
+      value: 'Bravo', propertyName: 'nullableTitle');
+
+  final eventDate = CurrentDateTimeProperty(
+    DateTime.utc(2024, 1, 2, 3, 4, 5),
+    propertyName: 'eventDate',
+  );
+
+  final nullableEventDate = CurrentNullableDateTimeProperty(
+    value: DateTime.utc(2024, 6, 7, 8, 9, 10),
+    propertyName: 'nullableEventDate',
+  );
+
+  final customObject = CurrentProperty<_TestCustomObject>(
+    const _TestCustomObject(id: 1, label: 'One'),
+    propertyName: 'customObject',
+  );
+
+  @override
+  Iterable<CurrentProperty> get currentProps => [
+        title,
+        nullableTitle,
+        eventDate,
+        nullableEventDate,
+        customObject,
+      ];
+}
+
 class _ControllerTestWidget extends CurrentWidget<_ControllerTestViewModel> {
   final CurrentTextController<String> nameController;
   final CurrentTextController<int> ageController;
@@ -81,6 +139,98 @@ class _ControllerTestState
             TextField(
               key: const Key('nullable-age-field'),
               controller: widget.nullableAgeController,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _AdditionalTypesControllerTestWidget
+    extends CurrentWidget<_AdditionalTypesViewModel> {
+  final CurrentTextController<String> titleController;
+  final CurrentTextController<String?> nullableTitleController;
+  final CurrentTextController<DateTime> eventDateController;
+  final CurrentTextController<DateTime?> nullableEventDateController;
+  final CurrentTextController<_TestCustomObject> customObjectController;
+
+  const _AdditionalTypesControllerTestWidget({
+    required super.viewModel,
+    required this.titleController,
+    required this.nullableTitleController,
+    required this.eventDateController,
+    required this.nullableEventDateController,
+    required this.customObjectController,
+  });
+
+  @override
+  CurrentState<CurrentWidget<CurrentViewModel>, _AdditionalTypesViewModel>
+      createCurrent() => _AdditionalTypesControllerTestState(viewModel);
+}
+
+class _AdditionalTypesControllerTestState extends CurrentState<
+    _AdditionalTypesControllerTestWidget,
+    _AdditionalTypesViewModel> with CurrentTextControllersLifecycleMixin {
+  _AdditionalTypesControllerTestState(super.viewModel);
+
+  @override
+  void bindCurrentControllers() {
+    widget.titleController.bindString(
+      property: viewModel.title,
+      lifecycleProvider: this,
+    );
+
+    widget.nullableTitleController.bindString(
+      property: viewModel.nullableTitle,
+      lifecycleProvider: this,
+    );
+
+    widget.eventDateController.bindDateTime(
+      property: viewModel.eventDate,
+      lifecycleProvider: this,
+      fromString: DateTime.parse,
+    );
+
+    widget.nullableEventDateController.bindDateTime(
+      property: viewModel.nullableEventDate,
+      lifecycleProvider: this,
+      fromString: DateTime.parse,
+    );
+
+    widget.customObjectController.bind(
+      property: viewModel.customObject,
+      lifecycleProvider: this,
+      fromString: _TestCustomObject.parse,
+      asString: (propertyValue) => propertyValue?.serialize(),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      home: Scaffold(
+        body: Column(
+          children: [
+            TextField(
+              key: const Key('title-field'),
+              controller: widget.titleController,
+            ),
+            TextField(
+              key: const Key('nullable-title-field'),
+              controller: widget.nullableTitleController,
+            ),
+            TextField(
+              key: const Key('event-date-field'),
+              controller: widget.eventDateController,
+            ),
+            TextField(
+              key: const Key('nullable-event-date-field'),
+              controller: widget.nullableEventDateController,
+            ),
+            TextField(
+              key: const Key('custom-object-field'),
+              controller: widget.customObjectController,
             ),
           ],
         ),
@@ -277,6 +427,142 @@ void main() {
       viewModel.alternateAge(21);
       await tester.pump();
       expect(ageController.text, '21');
+    });
+  });
+
+  group('CurrentTextController remaining supported types', () {
+    late _AdditionalTypesViewModel viewModel;
+    late CurrentTextController<String> titleController;
+    late CurrentTextController<String?> nullableTitleController;
+    late CurrentTextController<DateTime> eventDateController;
+    late CurrentTextController<DateTime?> nullableEventDateController;
+    late CurrentTextController<_TestCustomObject> customObjectController;
+
+    setUp(() {
+      viewModel = _AdditionalTypesViewModel();
+      titleController = CurrentTextController.string();
+      nullableTitleController = CurrentTextController.nullableString();
+      eventDateController = CurrentTextController.date();
+      nullableEventDateController = CurrentTextController.nullableDate();
+      customObjectController = CurrentTextController.of<_TestCustomObject>();
+    });
+
+    tearDown(() {
+      titleController.dispose();
+      nullableTitleController.dispose();
+      eventDateController.dispose();
+      nullableEventDateController.dispose();
+      customObjectController.dispose();
+    });
+
+    Future<void> pumpHarness(WidgetTester tester) async {
+      await tester.pumpWidget(
+        _AdditionalTypesControllerTestWidget(
+          viewModel: viewModel,
+          titleController: titleController,
+          nullableTitleController: nullableTitleController,
+          eventDateController: eventDateController,
+          nullableEventDateController: nullableEventDateController,
+          customObjectController: customObjectController,
+        ),
+      );
+    }
+
+    testWidgets('string properties sync in both directions', (tester) async {
+      await pumpHarness(tester);
+
+      expect(titleController.text, 'Alpha');
+
+      await tester.enterText(find.byKey(const Key('title-field')), 'Delta');
+      await tester.pump();
+
+      expect(viewModel.title.value, 'Delta');
+      expect(titleController.text, 'Delta');
+
+      viewModel.title('Echo');
+      await tester.pump();
+
+      expect(titleController.text, 'Echo');
+    });
+
+    testWidgets('nullable string properties clear when the field is cleared',
+        (tester) async {
+      await pumpHarness(tester);
+
+      expect(nullableTitleController.text, 'Bravo');
+
+      await tester.enterText(
+        find.byKey(const Key('nullable-title-field')),
+        '',
+      );
+      await tester.pump();
+
+      expect(viewModel.nullableTitle.value, isNull);
+      expect(nullableTitleController.text, '');
+    });
+
+    testWidgets(
+        'date properties parse input and update when the property value changes',
+        (tester) async {
+      await pumpHarness(tester);
+
+      final enteredDate = DateTime.utc(2025, 2, 3, 4, 5, 6);
+      final updatedDate = DateTime.utc(2026, 7, 8, 9, 10, 11);
+
+      expect(eventDateController.text,
+          viewModel.eventDate.value.toIso8601String());
+
+      await tester.enterText(
+        find.byKey(const Key('event-date-field')),
+        enteredDate.toIso8601String(),
+      );
+      await tester.pump();
+
+      expect(viewModel.eventDate.value, enteredDate);
+
+      viewModel.eventDate(updatedDate);
+      await tester.pump();
+
+      expect(eventDateController.text, updatedDate.toIso8601String());
+    });
+
+    testWidgets('nullable date properties clear when the field is cleared',
+        (tester) async {
+      await pumpHarness(tester);
+
+      await tester.enterText(
+        find.byKey(const Key('nullable-event-date-field')),
+        '',
+      );
+      await tester.pump();
+
+      expect(viewModel.nullableEventDate.value, isNull);
+      expect(nullableEventDateController.text, '');
+    });
+
+    testWidgets(
+        'custom object bindings parse input and update when the property value changes',
+        (tester) async {
+      await pumpHarness(tester);
+
+      const enteredObject = _TestCustomObject(id: 7, label: 'Skye');
+      const updatedObject = _TestCustomObject(id: 8, label: 'Luna');
+
+      expect(customObjectController.text, '1:One');
+
+      await tester.enterText(
+        find.byKey(const Key('custom-object-field')),
+        enteredObject.serialize(),
+      );
+      await tester.pump();
+
+      expect(viewModel.customObject.value, enteredObject);
+      expect(customObjectController.text, enteredObject.serialize());
+
+      viewModel.customObject(updatedObject);
+      await tester.pump();
+
+      expect(customObjectController.text, updatedObject.serialize());
     });
   });
 }

--- a/test/current_text_controller_test.dart
+++ b/test/current_text_controller_test.dart
@@ -304,6 +304,54 @@ void main() {
       expect(ageController.text, '11');
     });
 
+    testWidgets('setMultiple and resetAll update bound controller text',
+        (tester) async {
+      await tester.pumpWidget(
+        _ControllerTestWidget(
+          viewModel: viewModel,
+          nameController: nameController,
+          ageController: ageController,
+          nullableAgeController: nullableAgeController,
+        ),
+      );
+
+      viewModel.setMultiple([
+        {viewModel.name: 'Zoe'},
+        {viewModel.age: 33},
+      ]);
+      await tester.pump();
+
+      expect(nameController.text, 'Zoe');
+      expect(ageController.text, '33');
+
+      viewModel.resetAll();
+      await tester.pump();
+
+      expect(nameController.text, 'Alice');
+      expect(ageController.text, '10');
+    });
+
+    testWidgets('property reset updates bound controller text',
+        (tester) async {
+      await tester.pumpWidget(
+        _ControllerTestWidget(
+          viewModel: viewModel,
+          nameController: nameController,
+          ageController: ageController,
+          nullableAgeController: nullableAgeController,
+        ),
+      );
+
+      viewModel.name('Mila');
+      await tester.pump();
+      expect(nameController.text, 'Mila');
+
+      viewModel.name.reset();
+      await tester.pump();
+
+      expect(nameController.text, 'Alice');
+    });
+
     testWidgets(
         'invalid text stays visible and unrelated property events do not nuke it',
         (tester) async {

--- a/test/current_view_model_test.dart
+++ b/test/current_view_model_test.dart
@@ -195,6 +195,79 @@ void main() {
     );
   });
 
+  test('setMultiple - unchanged values - emits no events', () async {
+    var eventCount = 0;
+
+    final subscription = viewModel.addAnyStateChangedListener((_) {
+      eventCount++;
+    });
+
+    viewModel.setMultiple([
+      {viewModel.name: 'Bob'},
+      {viewModel.age: 20},
+    ]);
+    await Future<void>.microtask(() {});
+
+    expect(eventCount, equals(0));
+    expect(viewModel.name.value, equals('Bob'));
+    expect(viewModel.age.value, equals(20));
+
+    await subscription.cancel();
+  });
+
+  test('setMultiple - changed and unchanged values - emits only changed events',
+      () async {
+    final receivedEvents = <CurrentStateChanged>[];
+
+    final subscription = viewModel.addAnyStateChangedListener((event) {
+      receivedEvents.add(event);
+    });
+
+    viewModel.setMultiple([
+      {viewModel.name: 'Bob'},
+      {viewModel.age: 21},
+    ]);
+    await Future<void>.microtask(() {});
+
+    expect(receivedEvents.length, equals(1));
+    expect(
+      receivedEvents.single.propertyName,
+      equals(viewModel.age.propertyName),
+    );
+    expect(receivedEvents.single.previousValue, equals(20));
+    expect(receivedEvents.single.nextValue, equals(21));
+    expect(viewModel.name.value, equals('Bob'));
+    expect(viewModel.age.value, equals(21));
+
+    await subscription.cancel();
+  });
+
+  test('setMultiple - collection values with equal contents - emits no events',
+      () async {
+    var eventCount = 0;
+
+    final subscription =
+        collectionResetViewModel.addAnyStateChangedListener((_) {
+      eventCount++;
+    });
+
+    collectionResetViewModel.setMultiple([
+      {
+        collectionResetViewModel.items: <String>['Earth'],
+      },
+      {
+        collectionResetViewModel.data: <String, String>{'planet': 'Earth'},
+      },
+    ]);
+    await Future<void>.microtask(() {});
+
+    expect(eventCount, equals(0));
+    expect(collectionResetViewModel.items.value, equals(['Earth']));
+    expect(collectionResetViewModel.data.value, equals({'planet': 'Earth'}));
+
+    await subscription.cancel();
+  });
+
   test('addAnyErrorEventListener receives general error events', () async {
     ErrorEvent? receivedEvent;
 

--- a/test/current_view_model_test.dart
+++ b/test/current_view_model_test.dart
@@ -132,7 +132,7 @@ void main() {
   });
 
   test(
-      'isDirty - change property values, update original value, reset - isDirty is true',
+      'isDirty - change property values and update original values - isDirty is false',
       () {
     viewModel.name('Steve');
     viewModel.age(100);
@@ -195,7 +195,7 @@ void main() {
     );
   });
 
-  test('setMultiple - unchanged values - emits no events', () async {
+  test('setMultiple - unchanged scalar values - emits no events', () async {
     var eventCount = 0;
 
     final subscription = viewModel.addAnyStateChangedListener((_) {
@@ -215,7 +215,7 @@ void main() {
     await subscription.cancel();
   });
 
-  test('setMultiple - changed and unchanged values - emits only changed events',
+  test('setMultiple - mixed scalar changes - emits only changed events',
       () async {
     final receivedEvents = <CurrentStateChanged>[];
 

--- a/test/current_view_model_test.dart
+++ b/test/current_view_model_test.dart
@@ -1,6 +1,10 @@
 import 'package:current/current.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+class _TestFailureEvent extends ErrorEvent<String> {
+  _TestFailureEvent(super.error);
+}
+
 class _TestViewModel extends CurrentViewModel {
   final name = CurrentStringProperty('Bob');
   final age = CurrentIntProperty(20);
@@ -120,5 +124,22 @@ void main() {
     viewModel.age.setOriginalValueToCurrent();
 
     expect(viewModel.isDirty, isFalse);
+  });
+
+  test('addAnyErrorEventListener receives general error events', () async {
+    ErrorEvent? receivedEvent;
+
+    final subscription = viewModel.addAnyErrorEventListener((event) {
+      receivedEvent = event;
+    });
+
+    viewModel.notifyError(_TestFailureEvent('boom'));
+    await Future<void>.microtask(() {});
+
+    expect(receivedEvent, isNotNull);
+    expect(receivedEvent, isA<_TestFailureEvent>());
+    expect(receivedEvent?.error, 'boom');
+
+    await subscription.cancel();
   });
 }

--- a/test/current_view_model_test.dart
+++ b/test/current_view_model_test.dart
@@ -13,11 +13,20 @@ class _TestViewModel extends CurrentViewModel {
   Iterable<CurrentProperty> get currentProps => [name, age];
 }
 
+class _CollectionViewModel extends CurrentViewModel {
+  final items = CurrentListProperty<String>.empty();
+
+  @override
+  Iterable<CurrentProperty> get currentProps => [items];
+}
+
 void main() {
   late _TestViewModel viewModel;
+  late _CollectionViewModel collectionViewModel;
 
   setUp(() {
     viewModel = _TestViewModel();
+    collectionViewModel = _CollectionViewModel();
   });
 
   test(
@@ -124,6 +133,19 @@ void main() {
     viewModel.age.setOriginalValueToCurrent();
 
     expect(viewModel.isDirty, isFalse);
+  });
+
+  test('isDirty - collection properties at original values - isDirty is false',
+      () {
+    expect(collectionViewModel.items.isDirty, isFalse);
+    expect(collectionViewModel.isDirty, isFalse);
+  });
+
+  test('isDirty - collection properties after mutation - isDirty is true', () {
+    collectionViewModel.items.add('Mars', notifyChanges: false);
+
+    expect(collectionViewModel.items.isDirty, isTrue);
+    expect(collectionViewModel.isDirty, isTrue);
   });
 
   test('addAnyErrorEventListener receives general error events', () async {

--- a/test/current_view_model_test.dart
+++ b/test/current_view_model_test.dart
@@ -20,13 +20,23 @@ class _CollectionViewModel extends CurrentViewModel {
   Iterable<CurrentProperty> get currentProps => [items];
 }
 
+class _CollectionResetViewModel extends CurrentViewModel {
+  final items = CurrentListProperty<String>(['Earth']);
+  final data = CurrentMapProperty<String, String>({'planet': 'Earth'});
+
+  @override
+  Iterable<CurrentProperty> get currentProps => [items, data];
+}
+
 void main() {
   late _TestViewModel viewModel;
   late _CollectionViewModel collectionViewModel;
+  late _CollectionResetViewModel collectionResetViewModel;
 
   setUp(() {
     viewModel = _TestViewModel();
     collectionViewModel = _CollectionViewModel();
+    collectionResetViewModel = _CollectionResetViewModel();
   });
 
   test(
@@ -146,6 +156,43 @@ void main() {
 
     expect(collectionViewModel.items.isDirty, isTrue);
     expect(collectionViewModel.isDirty, isTrue);
+  });
+
+  test('resetAll - collection properties restore original values', () {
+    collectionResetViewModel.items.add('Mars', notifyChanges: false);
+    collectionResetViewModel.data.add('moon', 'Luna', notifyChanges: false);
+
+    collectionResetViewModel.resetAll();
+
+    expect(collectionResetViewModel.items.value, equals(['Earth']));
+    expect(
+      collectionResetViewModel.data.value,
+      equals({'planet': 'Earth'}),
+    );
+  });
+
+  test('resetAll - collection properties do not alias original values', () {
+    collectionResetViewModel.items.add('Mars', notifyChanges: false);
+    collectionResetViewModel.data.add('moon', 'Luna', notifyChanges: false);
+
+    collectionResetViewModel.resetAll();
+
+    collectionResetViewModel.items.add('Venus', notifyChanges: false);
+    collectionResetViewModel.data.add('star', 'Sun', notifyChanges: false);
+
+    expect(collectionResetViewModel.items.originalValue, equals(['Earth']));
+    expect(
+      collectionResetViewModel.data.originalValue,
+      equals({'planet': 'Earth'}),
+    );
+
+    collectionResetViewModel.resetAll();
+
+    expect(collectionResetViewModel.items.value, equals(['Earth']));
+    expect(
+      collectionResetViewModel.data.value,
+      equals({'planet': 'Earth'}),
+    );
   });
 
   test('addAnyErrorEventListener receives general error events', () async {

--- a/test/current_widget_test.dart
+++ b/test/current_widget_test.dart
@@ -29,6 +29,20 @@ class _TestViewModel extends CurrentViewModel {
   Iterable<CurrentProperty> get currentProps => [firstName, lastName, age];
 }
 
+class _LifecycleTrackingViewModel extends CurrentViewModel {
+  final title = CurrentStringProperty('Initial');
+  bool wasDisposed = false;
+
+  @override
+  Iterable<CurrentProperty> get currentProps => [title];
+
+  @override
+  void dispose() {
+    wasDisposed = true;
+    super.dispose();
+  }
+}
+
 class _MyWidget extends CurrentWidget<_TestViewModel> {
   final _ApplicationViewModel applicationViewModel;
   final _ApplicationSubViewModel appSubViewModel;
@@ -42,6 +56,34 @@ class _MyWidget extends CurrentWidget<_TestViewModel> {
   CurrentState<CurrentWidget<CurrentViewModel>, _TestViewModel>
       createCurrent() {
     return _MyWidgetState(viewModel);
+  }
+}
+
+class _LifecycleTrackingWidget
+    extends CurrentWidget<_LifecycleTrackingViewModel> {
+  const _LifecycleTrackingWidget({
+    required super.viewModel,
+    super.disposeViewModel,
+  });
+
+  @override
+  CurrentState<CurrentWidget<CurrentViewModel>, _LifecycleTrackingViewModel>
+      createCurrent() {
+    return _LifecycleTrackingWidgetState(viewModel);
+  }
+}
+
+class _LifecycleTrackingWidgetState extends CurrentState<
+    _LifecycleTrackingWidget, _LifecycleTrackingViewModel> {
+  _LifecycleTrackingWidgetState(super.viewModel);
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      home: Scaffold(
+        body: Text(viewModel.title.value),
+      ),
+    );
   }
 }
 
@@ -270,6 +312,64 @@ void main() {
   });
 
   group('Exception/Edge Case Testing', () {
+    testWidgets('CurrentWidget disposes owned view model by default',
+        (tester) async {
+      final viewModel = _LifecycleTrackingViewModel();
+
+      await tester.pumpWidget(
+        _LifecycleTrackingWidget(viewModel: viewModel),
+      );
+
+      expect(viewModel.wasDisposed, isFalse);
+
+      await tester.pumpWidget(const SizedBox.shrink());
+      await tester.pumpAndSettle();
+
+      expect(viewModel.wasDisposed, isTrue);
+    });
+
+    testWidgets(
+        'CurrentWidget can reassign and reuse a view model when disposeViewModel is false',
+        (tester) async {
+      final viewModel = _LifecycleTrackingViewModel();
+
+      await tester.pumpWidget(
+        _LifecycleTrackingWidget(
+          viewModel: viewModel,
+          disposeViewModel: false,
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      viewModel.title('First Mount');
+      await tester.pumpAndSettle();
+
+      expect(find.text('First Mount'), findsOneWidget);
+
+      await tester.pumpWidget(const SizedBox.shrink());
+      await tester.pumpAndSettle();
+
+      expect(viewModel.wasDisposed, isFalse);
+
+      viewModel.title('Reused');
+
+      await tester.pumpWidget(
+        _LifecycleTrackingWidget(
+          viewModel: viewModel,
+          disposeViewModel: false,
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(tester.takeException(), isNull);
+      expect(find.text('Reused'), findsOneWidget);
+
+      viewModel.title('Reassign');
+      await tester.pumpAndSettle();
+
+      expect(find.text('Reassign'), findsOneWidget);
+    });
+
     testWidgets(
         'EpireWidget Test - Attemp to share View Model Instance - Throws CurrentViewModelAlreadyAssignedException',
         (tester) async {

--- a/test/current_widget_test.dart
+++ b/test/current_widget_test.dart
@@ -371,7 +371,7 @@ void main() {
     });
 
     testWidgets(
-        'EpireWidget Test - Attemp to share View Model Instance - Throws CurrentViewModelAlreadyAssignedException',
+        'CurrentWidget Test - Attempt to share ViewModel instance - throws CurrentViewModelAlreadyAssignedException',
         (tester) async {
       late FlutterErrorDetails errorDetails;
       FlutterError.onError = (details) {


### PR DESCRIPTION
This pull request introduces the new `CurrentTextController` integration to the example counter app and adds comprehensive exception handling for text controller usage. It also improves the synchronization between UI text fields and the underlying `CurrentProperty` values, and clarifies the distinction between standard and current-aware text controllers in the UI. Additionally, internal changes enhance property change tracking and ViewModel reset behavior.

**CurrentTextController Integration & UI Enhancements:**

* Added `CurrentTextController.string()` for the `name` field in `CounterPage`, binding it to the `name` property in the ViewModel using the `CurrentTextControllersLifecycleMixin`. This keeps the text field in sync with the property automatically. (`example/lib/counter_page.dart` [[1]](diffhunk://#diff-ffe072f6c09ba8bbe432ca7f5dd65166ecc30cc08499323912175c40aaefff5fL18-R39) [[2]](diffhunk://#diff-ffe072f6c09ba8bbe432ca7f5dd65166ecc30cc08499323912175c40aaefff5fL118-R146)
* Updated the UI to include a name input field and a dynamic greeting, and added an explanatory message highlighting the difference between `CurrentTextController` and standard `TextEditingController`. (`example/lib/counter_page.dart` [[1]](diffhunk://#diff-ffe072f6c09ba8bbe432ca7f5dd65166ecc30cc08499323912175c40aaefff5fL118-R146) [[2]](diffhunk://#diff-ffe072f6c09ba8bbe432ca7f5dd65166ecc30cc08499323912175c40aaefff5fR226-R252)
* Exported `current_text_controller.dart` from the main library so it can be used externally. (`lib/current.dart` [lib/current.dartR9](diffhunk://#diff-e0cdf10b8c2604463c6e4c3ef2addb3e4c6c025449aa0aff0cf851eff753adeaR9))

**ViewModel and Property Improvements:**

* Added a `name` property to `CounterViewModel` and ensured it is included in the list of current properties, so it participates in state management. (`example/lib/counter_view_model.dart` [example/lib/counter_view_model.dartR5-R12](diffhunk://#diff-873dfb0d602c2ede0992d0896335e2a723c9a62a4581946327df0ca68134fc62R5-R12))
* Removed the obsolete `reset` method in favor of a more comprehensive reset mechanism. (`example/lib/counter_view_model.dart` [example/lib/counter_view_model.dartL29-L33](diffhunk://#diff-873dfb0d602c2ede0992d0896335e2a723c9a62a4581946327df0ca68134fc62L29-L33))

**Exception Handling for CurrentTextController:**

* Introduced several new exception classes for `CurrentTextController` to handle initialization, type mismatch, and usage errors, improving developer feedback and robustness. (`lib/src/current_exceptions.dart` [[1]](diffhunk://#diff-52c2cb976465e8496eb8ca4efdce748a6b511693c3270b114082912daad295b0R1-R2) [[2]](diffhunk://#diff-52c2cb976465e8496eb8ca4efdce748a6b511693c3270b114082912daad295b0R44-R47) [[3]](diffhunk://#diff-52c2cb976465e8496eb8ca4efdce748a6b511693c3270b114082912daad295b0R68-R124)

**Property Change Tracking:**

* Each `CurrentProperty` now has a unique `sourceHashCode` to better track the origin of changes, and this is included in all change notifications. (`lib/src/current_property.dart` [[1]](diffhunk://#diff-cdc02272ab020bf20549ace79dd250312f7d0fae89b7607f7a1af4d95cfcb3edR55-R56) [[2]](diffhunk://#diff-cdc02272ab020bf20549ace79dd250312f7d0fae89b7607f7a1af4d95cfcb3edL504-R511) [[3]](diffhunk://#diff-cdc02272ab020bf20549ace79dd250312f7d0fae89b7607f7a1af4d95cfcb3edR569) `lib/src/current_view_model.dart` [[4]](diffhunk://#diff-94fa380b3b4bc9774ef86dfdb5fb788ae2521f4c46ed081a76a3c09f074f228dL217-R218) [[5]](diffhunk://#diff-94fa380b3b4bc9774ef86dfdb5fb788ae2521f4c46ed081a76a3c09f074f228dR372-R375)

**ViewModel Reset Improvements:**

* Improved the ViewModel reset logic to clear busy task keys and ensure the ViewModel is not busy after a reset. (`lib/src/current_view_model.dart` [lib/src/current_view_model.dartR347-R348](diffhunk://#diff-94fa380b3b4bc9774ef86dfdb5fb788ae2521f4c46ed081a76a3c09f074f228dR347-R348))