### PR TITLE
Move VS Code Extension Context Menu Item To Bottom

### DIFF
--- a/vscode_extensions/current-flutter-snippets/README.md
+++ b/vscode_extensions/current-flutter-snippets/README.md
@@ -41,6 +41,10 @@ If you discover any issues with this extension please file an issue on the [Curr
 
 ## Release Notes
 
+### 2.0.1
+
+- Move the context menu command to the bottom of the menu to avoid conflicts with other commonly used context menu options like "New File" and "New Folder".
+
 ### 2.0.0
 
 - Updated extension name and description to better reflect available features

--- a/vscode_extensions/current-flutter-snippets/package.json
+++ b/vscode_extensions/current-flutter-snippets/package.json
@@ -3,7 +3,7 @@
   "displayName": "Flutter Current",
   "description": "Code snippets, commands, and code actions to speed up development workflow when using the Current state management package for Flutter.",
   "publisher": "ThirdVersionTechnologyLtd",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/thirdversion/flutter_current"
@@ -61,7 +61,7 @@
       "explorer/context": [
         {
           "command": "current-flutter-snippets.generateCurrentFiles",
-          "group": "navigation",
+          "group": "z_commands",
           "when": "explorerResourceIsFolder"
         }
       ]


### PR DESCRIPTION
Move new context menu item to the z-section of the context menu in VS Code. Previously this showed up at the top of the context menu, before the 'New File' item. Flutter Current is important, but not THAT important 😎