### PR TITLE
Auto CurrentTextController Disposal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 3.0.0-beta-6
+
+- `CurrentTextControllersLifecycleMixin` now automatically tracks and disposes `CurrentTextController` instances when the `dispose` method is called. This eliminates the need to manually call `dispose()` on controllers, reducing boilerplate and the risk of memory leaks.
+  - To support backwards compatibility or some case where manual disposal is still desired, `dispose()` on `CurrentTextController` is idempotent, meaning it is safe if you still have manual `dispose()` calls in your existing code.
+
 ## 3.0.0-beta-5
 
 **BREAKING CHANGES**

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ In your Flutter project, add the dependency to your `pubspec.yaml`.
 
 ```yaml
 dependencies:
-  current: ^3.0.0-beta-5
+  current: ^3.0.0-beta-6
 ```
 
 **Tip:** It is highly recommended to install the [Flutter Current](https://marketplace.visualstudio.com/items?itemName=ThirdVersionTechnologyLtd.current-flutter-snippets) extension in Visual Studio Code. It provides super helpful code snippets, commands, and Quick Fix actions to speed up your development workflow when using Flutter Current.

--- a/lib/src/current_text_controller.dart
+++ b/lib/src/current_text_controller.dart
@@ -699,6 +699,7 @@ class CurrentTextController<T> extends TextEditingController {
     _hasDefaultValue = !_isNullable && defaultValue != null;
     _treatTextAsStringValue = treatTextAsStringValue;
     _lifecycleProvider = lifecycleProvider;
+    lifecycleProvider._registerController(this);
     _validation = resolvedValidation;
     _validationIssues = validationIssues;
 
@@ -1001,8 +1002,17 @@ class CurrentTextController<T> extends TextEditingController {
     _validation!.setIssue(issue, markTouched: true);
   }
 
+  bool _isDisposed = false;
+
   @override
+  @mustCallSuper
   void dispose() {
+    if (_isDisposed) {
+      return;
+    }
+
+    _isDisposed = true;
+
     _subscription?.cancel();
     _subscription = null;
     _validation = null;
@@ -1426,6 +1436,11 @@ class _CurrentTextFieldState<T> extends State<CurrentTextField<T>> {
 mixin CurrentTextControllersLifecycleMixin<TWidget extends CurrentWidget,
     TViewModel extends CurrentViewModel> on CurrentState<TWidget, TViewModel> {
   bool _initializedControllers = false;
+  final Set<CurrentTextController<dynamic>> _managedControllers = {};
+
+  void _registerController(CurrentTextController<dynamic> controller) {
+    _managedControllers.add(controller);
+  }
 
   /// Whether the CurrentTextControllers have been initialized. This is used to ensure that the controllers are only initialized once.
   bool get controllersInitialized => _initializedControllers;
@@ -1450,5 +1465,14 @@ mixin CurrentTextControllersLifecycleMixin<TWidget extends CurrentWidget,
   void didUpdateWidget(covariant TWidget oldWidget) {
     super.didUpdateWidget(oldWidget);
     _bindOrRebindControllers();
+  }
+
+  @override
+  void dispose() {
+    for (final controller in _managedControllers) {
+      controller.dispose();
+    }
+    _managedControllers.clear();
+    super.dispose();
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: current
 description: A simple yet powerful state management library for Flutter. Keeps your widget build methods clean, with ZERO dependencies on other packages.
-version: 3.0.0-beta-5
+version: 3.0.0-beta-6
 homepage: https://github.com/thirdversion/flutter_current
 topics: [state-management, validation]
 issue_tracker: https://github.com/thirdversion/flutter_current/issues

--- a/test/current_text_controller_test.dart
+++ b/test/current_text_controller_test.dart
@@ -1256,6 +1256,33 @@ void main() {
       expect(find.text('Name is required.'), findsOneWidget);
       expect(requiredViewModel.nameValidation.isTouched, isTrue);
     });
+
+    test('dispose is idempotent', () {
+      final controller = CurrentTextController.string();
+      expect(() => controller.dispose(), returnsNormally);
+      expect(() => controller.dispose(), returnsNormally);
+    });
+
+    testWidgets('CurrentTextControllersLifecycleMixin automatically disposes registered controllers', (tester) async {
+      final viewModel = _ControllerValidationViewModel();
+      final controller = CurrentTextController.integer();
+
+      await tester.pumpWidget(
+        _ControllerValidationWidget(
+          viewModel: viewModel,
+          ageController: controller,
+        ),
+      );
+
+      // Verify the controller is not disposed yet (adding listener doesn't throw)
+      expect(() => controller.addListener(() {}), returnsNormally);
+
+      // Unmount the widget to trigger disposal
+      await tester.pumpWidget(const SizedBox());
+
+      // Verify the controller is disposed (adding listener throws)
+      expect(() => controller.addListener(() {}), throwsFlutterError);
+    });
   });
 }
 


### PR DESCRIPTION
The lifecycle mixin will now automatically track the disposal state of the controller. When the `State` object the mixin is applied to goes out of scope, the CurrentTextControllers will automatically get disposed with it, including detaching any listeners and clearing up validation resources.