### PR TITLE
Update Current Core / Resolve ChangeNotifier Mixin Overriding Dispose

### DIFF
--- a/lib/src/current_view_model.dart
+++ b/lib/src/current_view_model.dart
@@ -11,4 +11,11 @@ import 'package:flutter/foundation.dart';
 ///The [CurrentState] the ViewModel is bound to will update itself each time an [CurrentProperty] value
 ///is changed and call the states build function, updating the UI.
 abstract class CurrentViewModel extends CurrentStateViewModel
-    with ChangeNotifier {}
+    with ChangeNotifier {
+  @override
+  @mustCallSuper
+  void dispose() {
+    super.dispose();
+    disposeViewModel();
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
   flutter: ">=3.38.0"
 
 dependencies:
-  current_core: ^1.0.0
+  current_core: ^1.0.2
   flutter:
     sdk: flutter
 

--- a/test/current_view_model_test.dart
+++ b/test/current_view_model_test.dart
@@ -1,0 +1,21 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:current/current.dart';
+
+class _TestViewModel extends CurrentViewModel {
+  @override
+  Iterable<CurrentProperty> get currentProps => [];
+}
+
+void main() {
+  group('CurrentViewModel Tests', () {
+    test('dispose calls disposeViewModel and sets disposed to true', () {
+      final viewModel = _TestViewModel();
+      
+      expect(viewModel.disposed, isFalse);
+      
+      viewModel.dispose();
+      
+      expect(viewModel.disposed, isTrue);
+    });
+  });
+}


### PR DESCRIPTION
- Updates current_core to latest
- resolves an issue where applying the ChangeNotifier mixin was overriding the dispose function on the CurrentStateViewModel